### PR TITLE
Treat hyphens as part of the completion prefix

### DIFF
--- a/ovim-core/src/editor/input/insert_mode.rs
+++ b/ovim-core/src/editor/input/insert_mode.rs
@@ -22,8 +22,12 @@ fn is_completion_trigger_char(c: char) -> bool {
     matches!(c, '.')
 }
 
+// Looser than the motion-word rule on purpose: hyphens count so Tailwind
+// classes like `w-1/2` stay as one prefix and the menu doesn't collapse
+// mid-token. Keep in sync with `is_completion_keyword_char` in
+// `ovim-core/src/editor/lsp_modules/completion.rs`.
 fn is_completion_ident_char(c: char) -> bool {
-    c == '_' || c.is_alphanumeric()
+    c.is_alphanumeric() || c == '_' || c == '-'
 }
 
 /// Cleans up whitespace-only lines before exiting insert mode.

--- a/ovim-core/src/editor/lsp_modules/completion.rs
+++ b/ovim-core/src/editor/lsp_modules/completion.rs
@@ -245,6 +245,17 @@ fn filter_supported_trigger(trigger: Option<char>, supported: &HashSet<char>) ->
     }
 }
 
+/// Whether `c` is part of a completion-prefix keyword.
+///
+/// Looser than the Vim motion-word definition: hyphens count, so a Tailwind
+/// class like `w-1/2` is treated as one prefix when filtering completions and
+/// the menu doesn't collapse mid-token. Motion code (`dw`, `ciw`, etc.) keeps
+/// the strict alnum+`_` rule. Mirrored in `is_completion_ident_char` in
+/// `ovim-core/src/editor/input/insert_mode.rs`.
+fn is_completion_keyword_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-'
+}
+
 fn completion_trigger_context_from_line(line_text: &str, cursor_col: usize) -> (usize, String) {
     let cursor_byte = byte_offset_for_grapheme(line_text, cursor_col).unwrap_or(line_text.len());
     let before_cursor = &line_text[..cursor_byte.min(line_text.len())];
@@ -252,7 +263,7 @@ fn completion_trigger_context_from_line(line_text: &str, cursor_col: usize) -> (
     let mut start_byte = before_cursor.len();
     let graphemes: Vec<(usize, &str)> = grapheme_indices(before_cursor).collect();
     for (byte_offset, grapheme) in graphemes.into_iter().rev() {
-        let is_ident = grapheme.chars().all(|c| c == '_' || c.is_alphanumeric());
+        let is_ident = grapheme.chars().all(is_completion_keyword_char);
         if !is_ident {
             break;
         }
@@ -324,6 +335,22 @@ mod tests {
         let (col, prefix) = completion_trigger_context_from_line("__x1", 4);
         assert_eq!(col, 0);
         assert_eq!(prefix, "__x1");
+    }
+
+    // Tailwind classes contain hyphens; the fallback scanner must keep them
+    // as part of the prefix so filtering matches the LSP's view of the token.
+    #[test]
+    fn completion_trigger_context_hyphenated_prefix() {
+        let (col, prefix) = completion_trigger_context_from_line("class=\"bg-wh", 12);
+        assert_eq!(col, 7);
+        assert_eq!(prefix, "bg-wh");
+    }
+
+    #[test]
+    fn completion_trigger_context_trailing_hyphen() {
+        let (col, prefix) = completion_trigger_context_from_line("w-", 2);
+        assert_eq!(col, 0);
+        assert_eq!(prefix, "w-");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Tailwind LSP returns classes like `w-1/2` / `bg-white-500`, but the auto-trigger predicate and the fallback prefix scanner both treated `-` as a word boundary, so typing `bg-` collapsed the menu mid-class and Ctrl+N after `w-` filtered by `""`.
- Loosen the completion-keyword rule (and only that rule) to include `-`. Motion code (`dw`, `ciw`, Ctrl+W) keeps the strict alnum+`_` rule.

## Why this shape

nvim-cmp's default `keyword_pattern` accepts hyphens, blink.cmp's keyword regex is `[\p{L}0-9_-]*`, and VS Code's Tailwind extension ships a per-language `wordPattern` of `[\w-]+`. Every modern completion engine has converged on splitting motion-word from completion-keyword. This patch is the same split — minus the per-language plumbing, which the prior art shows isn't needed: hyphens being part of a completion prefix doesn't break any non-Tailwind language.

## Out of scope (deliberately)

- Honouring LSP-advertised trigger characters dynamically (Tailwind LSP advertises `-` as a trigger). Worth doing later — would auto-fire after a single `-` instead of waiting for two keyword chars — but step 1 alone makes the bug not-broken.
- `:` (Tailwind variants like `hover:bg-blue-500`) and `/` (opacity like `bg-white/50`). LSP `textEdit` ranges already cover these once the menu is open; revisit if users hit problems.

## Test plan

- [x] `cargo test -p ovim-core --lib completion_trigger_context` — 7/7 pass, including new `_hyphenated_prefix` and `_trailing_hyphen` cases.
- [x] `cargo test --workspace` — full suite green.
- [x] `cargo build -p ovim-core` clean (only pre-existing warnings).
- [ ] Manual TUI verification: open a JSX file with Tailwind LSP, type `<div class="w-` and confirm the menu surfaces `w-1/2`, `w-full`, etc., filtered by `w-`.