### PR TITLE
Attach visual selections to AI chat

### DIFF
--- a/ovim-core/src/dashboard.rs
+++ b/ovim-core/src/dashboard.rs
@@ -8,7 +8,7 @@
 pub const MENU_ITEMS: &[(&str, &str)] = &[
     ("<Space>sf", "Find a file"),
     ("<Space>sg", "Search the project"),
-    ("<Space><Space>", "AI chat"),
+    ("<Space><Space>", "AI chat · selected code attaches"),
     ("<Space>ca", "Code actions"),
     ("gd", "Jump to definition"),
     ("K", "Hover docs"),

--- a/ovim-core/src/editor/ai_chat_code_attachment.rs
+++ b/ovim-core/src/editor/ai_chat_code_attachment.rs
@@ -1,0 +1,75 @@
+use super::ai_chat_state::CodeAttachment;
+use super::Editor;
+
+const OPEN: &str = "<ovim-code-attachment>\n";
+const CLOSE: &str = "</ovim-code-attachment>\n";
+
+pub fn compose_code_attachment_message(attachment: &CodeAttachment, input: &str) -> String {
+    let path = attachment.path.as_deref().unwrap_or("untitled");
+    format!(
+        "{OPEN}path: {path}\nlines: {}-{}\nbuffer-revision: {}\n---\n{}\n{CLOSE}{}",
+        attachment.start_line + 1,
+        attachment.end_line + 1,
+        attachment.buffer_revision,
+        attachment.text,
+        input.trim(),
+    )
+}
+
+/// Returns the compact attachment label and the user-authored message body.
+pub fn split_code_attachment_message(content: &str) -> Option<(String, &str)> {
+    let body = content.strip_prefix(OPEN)?;
+    let (attachment, input) = body.split_once(CLOSE)?;
+    let mut lines = attachment.lines();
+    let path = lines.next()?.strip_prefix("path: ")?;
+    let range = lines.next()?.strip_prefix("lines: ")?;
+    Some((format!("{path}:{range}"), input))
+}
+
+impl Editor {
+    pub fn ai_chat_pending_code_attachment(&self) -> Option<&CodeAttachment> {
+        self.ai_state
+            .chat
+            .as_ref()
+            .and_then(|chat| chat.pending_code_attachment.as_ref())
+    }
+
+    pub fn remove_ai_chat_code_attachment(&mut self) -> bool {
+        self.ai_state
+            .chat
+            .as_mut()
+            .and_then(|chat| chat.pending_code_attachment.take())
+            .is_some()
+    }
+
+    pub fn ai_chat_pending_code_attachment_modified(&self) -> bool {
+        let Some(attachment) = self.ai_chat_pending_code_attachment() else {
+            return false;
+        };
+        self.get_buffer_by_id(attachment.buffer_id)
+            .map(|buffer| buffer.version() != attachment.buffer_revision)
+            .unwrap_or(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_round_trip_keeps_compact_label_and_draft() {
+        let attachment = CodeAttachment {
+            buffer_id: 7,
+            path: Some("src/main.rs".into()),
+            start_line: 4,
+            end_line: 6,
+            buffer_revision: 12,
+            text: "fn main() {}".into(),
+        };
+        let message = compose_code_attachment_message(&attachment, "Explain this");
+        let (label, draft) = split_code_attachment_message(&message).unwrap();
+        assert_eq!(label, "src/main.rs:5-7");
+        assert_eq!(draft, "Explain this");
+        assert!(message.contains("fn main() {}"));
+    }
+}

--- a/ovim-core/src/editor/ai_chat_commands.rs
+++ b/ovim-core/src/editor/ai_chat_commands.rs
@@ -307,6 +307,7 @@ impl Editor {
             chat.input.clear();
             chat.input_cursor = 0;
             chat.pending_images.clear();
+            chat.pending_code_attachment = None;
             chat.slash_completion_selected = 0;
         }
     }
@@ -336,6 +337,7 @@ impl Editor {
             chat.input.clear();
             chat.input_cursor = 0;
             chat.pending_images.clear();
+            chat.pending_code_attachment = None;
             chat.focus = ChatFocus::TextInput;
             chat.context_generation = chat.context_generation.saturating_add(1);
             chat.compaction_checkpoint = None;

--- a/ovim-core/src/editor/ai_chat_queue.rs
+++ b/ovim-core/src/editor/ai_chat_queue.rs
@@ -42,10 +42,11 @@ impl Editor {
     pub(crate) fn queue_current_ai_chat_input(&mut self, requested_kind: QueuedChatInputKind) {
         let input = self.ai_chat_input().trim().to_string();
         let has_images = !self.ai_chat_pending_images().is_empty();
-        if input.is_empty() && !has_images {
+        let has_code_attachment = self.ai_chat_pending_code_attachment().is_some();
+        if input.is_empty() && !has_images && !has_code_attachment {
             return;
         }
-        let kind = if has_images {
+        let kind = if has_images || has_code_attachment {
             // Codex steering currently accepts text items only. Keep image
             // messages intact for the next complete provider round.
             QueuedChatInputKind::FollowUp
@@ -61,11 +62,13 @@ impl Editor {
             chat.input.clear();
             chat.input_cursor = 0;
             let images = std::mem::take(&mut chat.pending_images);
+            let code_attachment = chat.pending_code_attachment.take();
             chat.queued_inputs.push_back(QueuedChatInput {
                 id,
                 kind,
                 content: input.clone(),
                 images,
+                code_attachment,
             });
             if kind == QueuedChatInputKind::Steer {
                 if let Some(tx) = chat
@@ -203,6 +206,7 @@ impl Editor {
             chat.input = item.content;
             chat.input_cursor = chat.input.len();
             chat.pending_images = item.images;
+            chat.pending_code_attachment = item.code_attachment;
             chat.history.selected_queued_id = None;
             chat.history.selected_node_id = None;
             chat.focus = crate::ai::chat_types::ChatFocus::TextInput;
@@ -220,6 +224,7 @@ impl Editor {
                 std::mem::take(&mut chat.input),
                 chat.input_cursor,
                 std::mem::take(&mut chat.pending_images),
+                chat.pending_code_attachment.take(),
             )
         });
 
@@ -240,6 +245,7 @@ impl Editor {
                     chat.input = item.content;
                     chat.input_cursor = chat.input.len();
                     chat.pending_images = item.images;
+                    chat.pending_code_attachment = item.code_attachment;
                 }
                 match item.kind {
                     QueuedChatInputKind::Command => {
@@ -260,10 +266,13 @@ impl Editor {
             }
         })();
 
-        if let (Some(chat), Some((input, cursor, images))) = (self.ai_state.chat.as_mut(), draft) {
+        if let (Some(chat), Some((input, cursor, images, code_attachment))) =
+            (self.ai_state.chat.as_mut(), draft)
+        {
             chat.input = input;
             chat.input_cursor = cursor.min(chat.input.len());
             chat.pending_images = images;
+            chat.pending_code_attachment = code_attachment;
         }
 
         result
@@ -329,6 +338,7 @@ mod tests {
             kind: QueuedChatInputKind::Steer,
             content: content.clone(),
             images: Vec::new(),
+            code_attachment: None,
         });
         chat.pending_code_explanation = Some(PendingCodeExplanation {
             tool_call: ToolCallInfo {
@@ -444,6 +454,7 @@ mod tests {
             kind: QueuedChatInputKind::FollowUp,
             content: "older queued follow-up".into(),
             images: Vec::new(),
+            code_attachment: None,
         });
 
         assert!(editor.start_next_queued_ai_chat_input().unwrap());

--- a/ovim-core/src/editor/ai_chat_state.rs
+++ b/ovim-core/src/editor/ai_chat_state.rs
@@ -563,6 +563,28 @@ pub struct QueuedChatInput {
     pub kind: QueuedChatInputKind,
     pub content: String,
     pub images: Vec<ImageAttachment>,
+    pub code_attachment: Option<CodeAttachment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeAttachment {
+    pub buffer_id: BufferId,
+    pub path: Option<String>,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub buffer_revision: usize,
+    pub text: String,
+}
+
+impl CodeAttachment {
+    pub fn label(&self) -> String {
+        let path = self.path.as_deref().unwrap_or("untitled");
+        if self.start_line == self.end_line {
+            format!("{path}:{}", self.start_line + 1)
+        } else {
+            format!("{path}:{}–{}", self.start_line + 1, self.end_line + 1)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -629,6 +651,8 @@ pub struct AiChatState {
     pub slash_completion_selected: usize,
     /// Images dropped into the current composer.
     pub pending_images: Vec<ImageAttachment>,
+    /// Visually selected code attached to the current composer.
+    pub pending_code_attachment: Option<CodeAttachment>,
     /// Image currently expanded over the chat panel.
     pub image_modal: Option<PathBuf>,
     /// First-run/recovery dialog for Ovim-owned Exa web search.
@@ -869,6 +893,7 @@ impl AiChatState {
             input_cursor: 0,
             slash_completion_selected: 0,
             pending_images: Vec::new(),
+            pending_code_attachment: None,
             image_modal: None,
             exa_setup: None,
             queued_inputs: VecDeque::new(),

--- a/ovim-core/src/editor/ai_chat_turn.rs
+++ b/ovim-core/src/editor/ai_chat_turn.rs
@@ -15,14 +15,15 @@ impl Editor {
     }
 
     fn submit_ai_chat_message_inner(&mut self, dispatch_slash_commands: bool) -> Result<()> {
-        let (input, has_pending_images) = match self.ai_state.chat.as_ref() {
+        let (input, has_pending_images, has_code_attachment) = match self.ai_state.chat.as_ref() {
             Some(chat) => (
                 chat.input.trim().to_string(),
                 !chat.pending_images.is_empty(),
+                chat.pending_code_attachment.is_some(),
             ),
             None => return Ok(()),
         };
-        if input.is_empty() && !has_pending_images {
+        if input.is_empty() && !has_pending_images && !has_code_attachment {
             return Ok(());
         }
 
@@ -45,6 +46,7 @@ impl Editor {
 
         if dispatch_slash_commands
             && !has_pending_images
+            && !has_code_attachment
             && self.try_execute_ai_chat_slash_command(&input)?
         {
             return Ok(());
@@ -54,10 +56,19 @@ impl Editor {
             return Ok(());
         }
 
-        let runtime_input = if input.is_empty() {
+        let message_input = self
+            .ai_state
+            .chat
+            .as_ref()
+            .and_then(|chat| chat.pending_code_attachment.as_ref())
+            .map(|attachment| {
+                super::ai_chat_code_attachment::compose_code_attachment_message(attachment, &input)
+            })
+            .unwrap_or_else(|| input.clone());
+        let runtime_input = if message_input.is_empty() {
             "[Image attachment]".to_string()
         } else {
-            input.clone()
+            message_input.clone()
         };
 
         // Queue, approval, and slash-command notices describe the previous
@@ -92,7 +103,7 @@ impl Editor {
             .unwrap_or_default();
         let user_node = self
             .conversation_mut()
-            .map(|conv| conv.append_user_message_with_images(input.clone(), images));
+            .map(|conv| conv.append_user_message_with_images(message_input, images));
         if let (Some(node_id), Some(event_id)) = (user_node, user_event_id) {
             self.record_ai_chat_node(node_id, event_id);
         }
@@ -101,6 +112,7 @@ impl Editor {
         let chat = self.ai_state.chat.as_mut().unwrap();
         chat.input.clear();
         chat.input_cursor = 0;
+        chat.pending_code_attachment = None;
         chat.waiting = true;
         chat.viewport.row_scroll_from_bottom = 0;
         chat.viewport.follow_latest = true;

--- a/ovim-core/src/editor/ai_integration.rs
+++ b/ovim-core/src/editor/ai_integration.rs
@@ -176,10 +176,29 @@ impl Editor {
             allow_edits: true,
             ..Default::default()
         })?;
-        self.set_status_message(
-            "AI chat opened with selection context. Describe the change; surrounding edits are allowed."
-                .to_string(),
-        );
+        let selection = self
+            .ai_state
+            .active_selection
+            .as_ref()
+            .expect("selection was captured")
+            .clone();
+        let buffer = self
+            .get_buffer_by_id(selection.buffer_id)
+            .expect("selected buffer remains open");
+        let attachment = super::ai_chat_state::CodeAttachment {
+            buffer_id: selection.buffer_id,
+            path: buffer.file_path().map(ToString::to_string),
+            start_line: selection.start_line,
+            end_line: selection.end_line,
+            buffer_revision: buffer.version(),
+            text: selection.selected_text,
+        };
+        let label = attachment.label();
+        if let Some(chat) = self.ai_state.chat.as_mut() {
+            chat.active_buffer_id = selection.buffer_id;
+            chat.pending_code_attachment = Some(attachment);
+        }
+        self.set_status_message(format!("Attached {label} to AI chat"));
         Ok(())
     }
 

--- a/ovim-core/src/editor/input/ai_chat_mode.rs
+++ b/ovim-core/src/editor/input/ai_chat_mode.rs
@@ -308,7 +308,7 @@ fn handle_text_input(editor: &mut Editor, key_event: KeyEvent) -> Result<()> {
             editor.reset_ai_chat_slash_completion();
         }
         KeyCode::Backspace => {
-            let mut remove_image = false;
+            let mut remove_attachment = false;
             if let Some(chat) = editor.ai_state.chat.as_mut() {
                 let pos = chat.input_cursor;
                 if pos > 0 {
@@ -320,10 +320,10 @@ fn handle_text_input(editor: &mut Editor, key_event: KeyEvent) -> Result<()> {
                     chat.input.remove(prev);
                     chat.input_cursor = prev;
                 } else if chat.input.is_empty() {
-                    remove_image = true;
+                    remove_attachment = true;
                 }
             }
-            if remove_image {
+            if remove_attachment && !editor.remove_ai_chat_code_attachment() {
                 editor.remove_last_ai_chat_image();
             }
             editor.reset_ai_chat_slash_completion();

--- a/ovim-core/src/editor/input/visual_mode.rs
+++ b/ovim-core/src/editor/input/visual_mode.rs
@@ -127,9 +127,9 @@ fn handle_visual_leader_input(
 
     if keys.is_empty() {
         match c {
-            // <Space><Space> in visual mode: edit the selection inline.
+            // <Space><Space> in visual mode: attach the selection to AI chat.
             ' ' => {
-                editor.start_ai_prompt_from_visual()?;
+                editor.start_ai_chat_from_visual()?;
                 editor.reset_input_state();
             }
             _ => {

--- a/ovim-core/src/editor/mod.rs
+++ b/ovim-core/src/editor/mod.rs
@@ -1,6 +1,7 @@
 mod ai_agent;
 mod ai_base_manifest;
 mod ai_chat;
+mod ai_chat_code_attachment;
 mod ai_chat_commands;
 mod ai_chat_exa;
 mod ai_chat_images;
@@ -101,10 +102,11 @@ pub use crate::change::{
     ApplyPos, Change, ChangeBuilder, ChangeManager, CursorPos, InsertEntryMode, Range,
     TextObjectType,
 };
+pub use ai_chat_code_attachment::split_code_attachment_message;
 pub use ai_chat_commands::AiChatSlashCompletion;
 pub use ai_chat_session::AI_CHAT_REASONING_EFFORTS;
 pub use ai_chat_state::{
-    AiChatActivity, ChatModelPickerSection, ComprehensionPolicy, QueuedChatInput,
+    AiChatActivity, ChatModelPickerSection, CodeAttachment, ComprehensionPolicy, QueuedChatInput,
     QueuedChatInputKind,
 };
 pub use ai_shell_process::{ShellInspectorView, ShellProcessPhase};

--- a/ovim/src/ui/renderer/ai_chat.rs
+++ b/ovim/src/ui/renderer/ai_chat.rs
@@ -1752,6 +1752,29 @@ fn render_chat_bubble(
 
     let inner_width = card_text_width(panel_width, accent_glyph);
 
+    let (code_attachment_label, visible_content) = if message.role == ChatRole::User {
+        if let Some((label, content)) =
+            ovim_core::editor::split_code_attachment_message(&message.content)
+        {
+            (Some(label), content)
+        } else {
+            (None, message.content.as_str())
+        }
+    } else {
+        (None, message.content.as_str())
+    };
+
+    if let Some(label) = code_attachment_label {
+        lines.push(render_card_text_line(
+            panel_width,
+            accent_glyph,
+            row_style.accent,
+            row_style.body_bg,
+            &format!("📎 {label}"),
+            Style::default().fg(ACCENT_USER).add_modifier(Modifier::DIM),
+        ));
+    }
+
     if terminal_image_support && !message.images.is_empty() {
         let (image_lines, image_placements) = render_message_image_boxes(
             &message.images,
@@ -1815,7 +1838,7 @@ fn render_chat_bubble(
         let display_content = if message.role == ChatRole::Thinking {
             format!("\u{25be} {}", message.content)
         } else {
-            message.content.clone()
+            visible_content.to_string()
         };
         let wrapped = word_wrap(&display_content, inner_width);
         for row in &wrapped {
@@ -2081,16 +2104,28 @@ fn render_text_input(
         .iter()
         .map(|image| image.file_name())
         .collect::<Vec<_>>();
+    let code_attachment = editor.ai_chat_pending_code_attachment().map(|attachment| {
+        let suffix = if editor.ai_chat_pending_code_attachment_modified() {
+            " · modified"
+        } else {
+            ""
+        };
+        format!("{}{suffix}", attachment.label())
+    });
     let composer_title = editor.ai_agent_composer_title();
     let top = if let Some(title) = composer_title {
         let title = truncate_with_ellipsis(&title, w.saturating_sub(4));
         let fill = w.saturating_sub(2 + text_display_width(&title));
         format!("╭{title}{}╮", "─".repeat(fill))
-    } else if image_names.is_empty() {
+    } else if image_names.is_empty() && code_attachment.is_none() {
         format!("╭{}╮", "─".repeat(w.saturating_sub(2)))
     } else {
+        let mut attachments = image_names;
+        if let Some(label) = code_attachment {
+            attachments.push(label);
+        }
         let title = truncate_with_ellipsis(
-            &format!(" 📎 {} ", image_names.join(", ")),
+            &format!(" 📎 {} ", attachments.join(", ")),
             w.saturating_sub(4),
         );
         let fill = w.saturating_sub(2 + text_display_width(&title));

--- a/ovim/tests/ai_prompt_test.rs
+++ b/ovim/tests/ai_prompt_test.rs
@@ -65,36 +65,52 @@ fn generated_region(
 }
 
 #[test]
-fn test_visual_space_space_enters_ai_prompt_mode() {
+fn test_visual_space_space_attaches_selection_to_chat() {
     let mut test = EditorTest::new("hello world\n");
 
     test.keys("vll<Space><Space>");
 
-    test.assert_mode(Mode::AiPrompt);
-    let selection = test
+    test.assert_mode(Mode::AiChat);
+    let attachment = test
         .editor
-        .ai_state
-        .active_selection
-        .as_ref()
-        .expect("expected active AI selection");
-    assert_eq!(selection.selected_text, "hel");
-    assert_eq!(test.editor.ai_prompt_input(), "");
+        .ai_chat_pending_code_attachment()
+        .expect("expected attached code selection");
+    assert_eq!(attachment.text, "hel");
+    assert_eq!(test.editor.ai_chat_input(), "");
 }
 
 #[test]
-fn test_visual_line_ai_selection_keeps_indent_and_trailing_newline() {
+fn test_visual_line_chat_attachment_keeps_indent_and_trailing_newline() {
     let mut test = EditorTest::new("    one\n    two\nnext\n");
 
     test.keys("Vj<Space><Space>");
 
-    test.assert_mode(Mode::AiPrompt);
-    let selection = test
+    test.assert_mode(Mode::AiChat);
+    let attachment = test
         .editor
-        .ai_state
-        .active_selection
-        .as_ref()
-        .expect("expected active AI selection");
-    assert_eq!(selection.selected_text, "    one\n    two\n");
+        .ai_chat_pending_code_attachment()
+        .expect("expected attached code selection");
+    assert_eq!(attachment.text, "    one\n    two\n");
+}
+
+#[test]
+fn test_visual_chat_attachment_preserves_existing_draft() {
+    let mut test = EditorTest::new("hello world\n");
+    test.keys("<Space><Space>");
+    test.type_text("Please explain this");
+    test.press_esc();
+
+    test.keys("vll<Space><Space>");
+
+    test.assert_mode(Mode::AiChat);
+    assert_eq!(test.editor.ai_chat_input(), "Please explain this");
+    assert_eq!(
+        test.editor
+            .ai_chat_pending_code_attachment()
+            .expect("expected attached selection")
+            .text,
+        "hel"
+    );
 }
 
 #[test]
@@ -155,7 +171,8 @@ fn test_normal_space_space_opens_ai_chat_with_chat_context_profile() {
 fn test_ai_prompt_escape_clears_state() {
     let mut test = EditorTest::new("hello world\n");
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.type_text("rewrite it");
     test.press_esc();
 
@@ -168,7 +185,8 @@ fn test_ai_prompt_escape_clears_state() {
 fn test_ai_prompt_arrow_navigation_edits_prompt() {
     let mut test = EditorTest::new("hello world\n");
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.type_text("abc");
     test.press_key(KeyCode::Left);
     test.press('X');
@@ -294,7 +312,8 @@ async fn test_ai_prompt_submit_creates_lock_and_returns_to_normal() {
         .profiles
         .insert("test".to_string(), profile);
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.type_text("replace with short word");
     test.press_enter();
 
@@ -329,7 +348,8 @@ async fn test_ai_prompt_submit_applies_context_budget_trace() {
         .profiles
         .insert("budget".to_string(), profile);
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.type_text("rewrite");
     test.press_enter();
 
@@ -368,7 +388,8 @@ fn test_ai_prompt_keyboard_model_picker_cycles_profiles() {
     test.editor.ai_state.active_profile = "alpha".to_string();
     test.editor.ai_state.edit_format = EditFormat::Json;
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.press_key(KeyCode::Tab);
     assert_eq!(test.editor.ai_state.active_profile, "beta");
     assert_eq!(test.editor.ai_state.edit_format, EditFormat::Codeblock);
@@ -455,7 +476,8 @@ fn test_ai_prompt_mouse_model_picker_selects_profile() {
     test.editor.ai_state.active_profile = "alpha".to_string();
     test.editor.ai_state.edit_format = EditFormat::Json;
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.editor.ai_state.prompt.model_picker_open = true;
     test.editor.render_cache.ai_prompt_model_hitboxes = vec![
         (
@@ -496,7 +518,8 @@ fn test_ai_prompt_mouse_model_picker_selects_profile() {
 #[test]
 fn test_ai_prompt_mouse_model_picker_trigger_toggles_open_state() {
     let mut test = EditorTest::new("hello world\n");
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.editor.render_cache.ai_prompt_model_trigger_hitbox = Some(Rect {
         x: 10,
         y: 20,
@@ -546,7 +569,8 @@ fn test_ai_prompt_enter_applies_open_picker_selection_instead_of_submitting() {
         .profiles
         .insert("beta".to_string(), beta);
 
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.editor.ai_state.prompt.input = "rewrite".to_string();
     test.editor.ai_state.prompt.cursor = 7;
     test.editor.ai_state.prompt.model_picker_open = true;
@@ -561,7 +585,8 @@ fn test_ai_prompt_enter_applies_open_picker_selection_instead_of_submitting() {
 #[test]
 fn test_ai_prompt_ctrl_m_toggles_picker_and_esc_closes_picker_first() {
     let mut test = EditorTest::new("hello world\n");
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.press_with(KeyCode::Char('m'), Modifiers::CONTROL);
     assert!(test.editor.ai_state.prompt.model_picker_open);
 
@@ -573,7 +598,8 @@ fn test_ai_prompt_ctrl_m_toggles_picker_and_esc_closes_picker_first() {
 #[test]
 fn test_ai_prompt_mouse_click_sets_cursor_on_wrapped_rows() {
     let mut test = EditorTest::new("hello world\n");
-    test.keys("vll<Space><Space>");
+    test.keys("vll");
+    test.editor.start_ai_prompt_from_visual().unwrap();
     test.editor.ai_state.prompt.input = "abcdefghij".to_string();
     test.editor.ai_state.prompt.cursor = 0;
     test.editor.render_cache.ai_prompt_input_rows = vec![

--- a/user-docs/ai.md
+++ b/user-docs/ai.md
@@ -9,8 +9,9 @@ This guide covers practical AI configuration in ovim:
 
 ## Recommendation
 
-Open AI chat with `Space Space`, or visually select text and press
-`Space Space`. When a direct Codex profile needs credentials, Ovim shows a
+Open AI chat with `Space Space`. Visually select text and press `Space Space`
+to open the same chat with that code attached to the composer. When a direct
+Codex profile needs credentials, Ovim shows a
 sign-in dialog at the point of use:
 
 1. Press `Enter` to open ChatGPT sign-in in your browser.
@@ -559,7 +560,7 @@ Built-in AI keybindings:
 
 - Normal mode `Space Space`: chat
 - Normal mode `Space ?`: read-only query
-- Visual mode `Space Space`: single-shot selection edit
+- Visual mode `Space Space`: attach selected code to chat
 - AI chat `Ctrl-T`: delegated-agent and conversation-tree sidebar
 
 ## Legacy `ai.toml` (Still Supported)

--- a/user-docs/getting-started.md
+++ b/user-docs/getting-started.md
@@ -42,7 +42,7 @@ and the explorer root cannot be renamed, moved, or deleted.
 ## AI Chat and Editing
 
 Press `Space Space` in normal mode to open AI chat. Select text visually and
-press `Space Space` to request an edit. The built-in Codex profiles use your
+press `Space Space` to open the same chat with that code attached. The built-in Codex profiles use your
 ChatGPT subscription.
 
 On first use, Ovim checks its credentials and opens a sign-in dialog. Press


### PR DESCRIPTION
## What changed

- route visual-mode `Space Space` into the existing AI chat instead of the one-shot AI prompt
- attach selected code to the composer with file, line range, and buffer revision metadata
- preserve existing drafts and queue attachments safely during active turns
- render compact code-attachment labels in the composer and submitted message history
- flag attachments whose source buffer changed before submission
- update the startup shortcut label and AI documentation

## Why

Visual selection AI previously opened a separate one-shot editing mode, splitting the AI workflow across two experiences. Treating selected code like an attachment keeps the interaction in the durable, tool-capable chat while preserving the selection as high-priority context and allowing broader edits.

## Impact

Users can visually select code and press `Space Space` to continue in the normal chat. Existing chat drafts are preserved, broader edits target the selected buffer, and the legacy inline prompt remains internally available without owning the visual shortcut.

## Validation

- `cargo test --workspace`
- repository pre-commit `cargo fmt`
- repository pre-commit `cargo clippy`
- Impeccable UI detector: no findings
- `git diff --check`
