### PR TITLE
Add durable agent handoff attachments

### DIFF
--- a/ovim-core/src/agent_runtime/dispatch.rs
+++ b/ovim-core/src/agent_runtime/dispatch.rs
@@ -14,9 +14,9 @@ use crate::run_log::{
     AgentLifecycleEvent, AgentLifecycleState, AgentModelEffortSnapshot,
     AgentModelFallbackPolicySnapshot, AgentModelRouteResolutionSnapshot,
     AgentRequestedModelRouteSnapshot, AgentResolvedModelRouteSnapshot,
-    AgentWorkspacePolicySnapshot, AgentWorkspaceStrategySnapshot, EventActor, EventEnvelope,
-    EventId, EventKind, ManifestId, NewRunEvent, OperationId, RunEventSink, RunId, RunLogError,
-    ToolOutcome, TurnId, WorkspaceId, AGENT_FOLLOWUP_EVENT_VERSION,
+    AgentWorkspacePolicySnapshot, AgentWorkspaceStrategySnapshot, ArtifactId, EventActor,
+    EventEnvelope, EventId, EventKind, ManifestId, NewRunEvent, OperationId, RunEventSink, RunId,
+    RunLogError, ToolOutcome, TurnId, WorkspaceId, AGENT_FOLLOWUP_EVENT_VERSION,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
@@ -1248,6 +1248,37 @@ impl AgentDispatchScheduler {
             .collect::<Vec<_>>();
         records.sort_by_key(|agent| agent.queue_sequence);
         records
+    }
+
+    pub fn validate_handoff_attachments(
+        &self,
+        handle: &DispatchHandle,
+        attachments: &[ArtifactId],
+    ) -> Result<(), String> {
+        if !self.agents.contains_key(&handle.agent_id) {
+            return Err(format!("unknown agent {}", handle.agent_id));
+        }
+        let events = self
+            .sink
+            .events(&self.run_id)
+            .map_err(|error| error.to_string())?;
+        for artifact_id in attachments {
+            let owned = events.iter().any(|event| {
+                event.agent_id.as_ref() == Some(&handle.agent_id)
+                    && matches!(
+                        &event.kind,
+                        EventKind::AgentAttachment(attachment)
+                            if attachment.artifact.artifact_id == *artifact_id
+                    )
+            });
+            if !owned {
+                return Err(format!(
+                    "artifact {artifact_id} was not durably created by agent {}",
+                    handle.agent_id
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Append a provider/tool event to this child’s causal trace and advance
@@ -2628,7 +2659,9 @@ mod tests {
     };
     use crate::ai::AiConfig;
     use crate::run_log::{
-        AgentModelProfileSnapshot, InMemoryRunEventSink, MessageEvent, MessageRole,
+        AgentAttachmentEvent, AgentModelProfileSnapshot, ArtifactExportPolicy, ArtifactRecord,
+        ArtifactRetention, ArtifactSource, ArtifactState, BlobId, ContentRepresentation,
+        InMemoryRunEventSink, MessageEvent, MessageRole, AGENT_ATTACHMENT_EVENT_VERSION,
     };
 
     fn catalog() -> Arc<SubagentModelCatalog> {
@@ -2643,6 +2676,76 @@ mod tests {
             catalog(),
         );
         (scheduler, sink)
+    }
+
+    #[test]
+    fn handoff_attachment_references_must_be_durable_and_owned() {
+        let (mut scheduler, sink) = scheduler();
+        let first = scheduler
+            .dispatch(request(
+                AgentRoleTemplate::built_in(AgentKindName::Explorer),
+                WorkspaceId::new(),
+                WorkspaceStrategy::ReadOnlySnapshot { manifest_id: None },
+            ))
+            .unwrap();
+        let second = scheduler
+            .dispatch(request(
+                AgentRoleTemplate::built_in(AgentKindName::Explorer),
+                WorkspaceId::new(),
+                WorkspaceStrategy::ReadOnlySnapshot { manifest_id: None },
+            ))
+            .unwrap();
+        let artifact_id = ArtifactId::new();
+        let cause = sink
+            .events(&first.run_id)
+            .unwrap()
+            .last()
+            .unwrap()
+            .event_id
+            .clone();
+        sink.append(NewRunEvent {
+            run_id: first.run_id.clone(),
+            caused_by: Some(cause),
+            operation_id: None,
+            provider_call_id: None,
+            actor: EventActor::Agent(first.agent_id.clone()),
+            agent_id: Some(first.agent_id.clone()),
+            turn_id: None,
+            workspace_id: Some(first.workspace.workspace_id.clone()),
+            branch_id: None,
+            kind: EventKind::AgentAttachment(AgentAttachmentEvent {
+                version: AGENT_ATTACHMENT_EVENT_VERSION,
+                name: "report.md".into(),
+                artifact: ArtifactRecord {
+                    artifact_id: artifact_id.clone(),
+                    state: ArtifactState::Available {
+                        blob_id: BlobId::digest(b"report"),
+                        byte_len: 6,
+                    },
+                    source: ArtifactSource::Imported {
+                        label: Some("report.md".into()),
+                    },
+                    representation: ContentRepresentation::EditorText {
+                        encoding: Some("utf-8".into()),
+                        line_endings: None,
+                    },
+                    media_type: Some("text/markdown".into()),
+                    retention: ArtifactRetention::Run,
+                    export_policy: ArtifactExportPolicy::Include,
+                },
+            }),
+        })
+        .unwrap();
+
+        assert!(scheduler
+            .validate_handoff_attachments(&first, std::slice::from_ref(&artifact_id))
+            .is_ok());
+        assert!(scheduler
+            .validate_handoff_attachments(&second, std::slice::from_ref(&artifact_id))
+            .is_err());
+        assert!(scheduler
+            .validate_handoff_attachments(&first, &[ArtifactId::new()])
+            .is_err());
     }
 
     fn request(

--- a/ovim-core/src/agent_runtime/dispatch.rs
+++ b/ovim-core/src/agent_runtime/dispatch.rs
@@ -1658,6 +1658,7 @@ fn is_runtime_trace_event(kind: &EventKind) -> bool {
         EventKind::AgentProvider(_)
             | EventKind::AgentUsage(_)
             | EventKind::AgentProgress(_)
+            | EventKind::AgentHandoffValidationFailed(_)
             | EventKind::ToolIntent(_)
             | EventKind::ToolStarted(_)
             | EventKind::ToolResult(_)
@@ -1670,7 +1671,10 @@ fn validate_runtime_operation(
     operation_id: Option<&OperationId>,
 ) -> Result<(), DispatchError> {
     match kind {
-        EventKind::AgentProvider(_) | EventKind::AgentUsage(_) | EventKind::AgentProgress(_)
+        EventKind::AgentProvider(_)
+        | EventKind::AgentUsage(_)
+        | EventKind::AgentProgress(_)
+        | EventKind::AgentHandoffValidationFailed(_)
             if operation_id.is_none() =>
         {
             Ok(())
@@ -1721,7 +1725,10 @@ fn apply_runtime_operation(
     operation_id: Option<&OperationId>,
 ) -> Result<(), DispatchError> {
     match kind {
-        EventKind::AgentProvider(_) | EventKind::AgentUsage(_) | EventKind::AgentProgress(_) => {}
+        EventKind::AgentProvider(_)
+        | EventKind::AgentUsage(_)
+        | EventKind::AgentProgress(_)
+        | EventKind::AgentHandoffValidationFailed(_) => {}
         EventKind::ToolIntent(_) => {
             agent.runtime_operations.insert(
                 operation_id.expect("validated operation ID").clone(),
@@ -2659,9 +2666,10 @@ mod tests {
     };
     use crate::ai::AiConfig;
     use crate::run_log::{
-        AgentAttachmentEvent, AgentModelProfileSnapshot, ArtifactExportPolicy, ArtifactRecord,
-        ArtifactRetention, ArtifactSource, ArtifactState, BlobId, ContentRepresentation,
-        InMemoryRunEventSink, MessageEvent, MessageRole, AGENT_ATTACHMENT_EVENT_VERSION,
+        AgentAttachmentEvent, AgentHandoffValidationFailedEvent, AgentModelProfileSnapshot,
+        ArtifactExportPolicy, ArtifactRecord, ArtifactRetention, ArtifactSource, ArtifactState,
+        BlobId, ContentRepresentation, InMemoryRunEventSink, MessageEvent, MessageRole,
+        AGENT_ATTACHMENT_EVENT_VERSION, AGENT_HANDOFF_VALIDATION_FAILED_EVENT_VERSION,
     };
 
     fn catalog() -> Arc<SubagentModelCatalog> {
@@ -3269,6 +3277,43 @@ mod tests {
             scheduler.state(&handle.agent_id),
             Some(&DispatchState::Queued)
         );
+    }
+
+    #[test]
+    fn invalid_handoff_payload_is_a_valid_runtime_trace_event() {
+        let (mut scheduler, sink) = scheduler();
+        let handle = scheduler
+            .dispatch(request(
+                AgentKind::built_in(AgentKindName::Explorer),
+                WorkspaceId::parse("wsp_invalid_handoff_trace").unwrap(),
+                WorkspaceStrategy::ReadOnlySnapshot { manifest_id: None },
+            ))
+            .unwrap();
+        start_running(&mut scheduler, &handle);
+
+        let event = scheduler
+            .record_runtime_event(
+                &handle,
+                EventKind::AgentHandoffValidationFailed(AgentHandoffValidationFailedEvent {
+                    version: AGENT_HANDOFF_VALIDATION_FAILED_EVENT_VERSION,
+                    error: "attachment reference was not durable".into(),
+                    raw_payload: br#"{"version":1}"#.to_vec(),
+                    repair_attempted: true,
+                }),
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            event.kind,
+            EventKind::AgentHandoffValidationFailed(_)
+        ));
+        assert!(sink
+            .events(&handle.run_id)
+            .unwrap()
+            .iter()
+            .any(|stored| stored.event_id == event.event_id));
     }
 
     #[test]

--- a/ovim-core/src/agent_runtime/dispatch.rs
+++ b/ovim-core/src/agent_runtime/dispatch.rs
@@ -1765,6 +1765,7 @@ pub(crate) fn validated_terminal_handoff(
                 verification: Vec::new(),
                 blockers: vec![detail],
                 followups: Vec::new(),
+                attachments: Vec::new(),
                 confidence: HandoffConfidence::Low,
             },
             Some(status),
@@ -2699,6 +2700,7 @@ mod tests {
                         .into_iter()
                         .collect(),
                     followups: vec![],
+                    attachments: vec![],
                     confidence: HandoffConfidence::High,
                 },
                 Some(status),

--- a/ovim-core/src/agent_runtime/fake_provider.rs
+++ b/ovim-core/src/agent_runtime/fake_provider.rs
@@ -581,6 +581,7 @@ mod tests {
             BTreeSet::from([
                 "cancellation",
                 "delayed_completion",
+                "invalid_attachment_handoff",
                 "malformed_handoff",
                 "out_of_order_completion",
                 "restart",

--- a/ovim-core/src/agent_runtime/fixtures/fake-provider-v1.json
+++ b/ovim-core/src/agent_runtime/fixtures/fake-provider-v1.json
@@ -128,6 +128,34 @@
       ]
     },
     {
+      "name": "invalid_attachment_handoff",
+      "description": "The provider references an attachment that was never durably created.",
+      "calls": [
+        {
+          "call_id": "invalid-attachment-handoff",
+          "events": [
+            { "at_tick": 0, "type": "started" },
+            {
+              "at_tick": 1,
+              "type": "handoff",
+              "payload": {
+                "version": 1,
+                "status": "completed",
+                "summary": "Completed with an invented attachment.",
+                "evidence": [{"path":"src/lib.rs","line":1,"claim":"Inspected the source."}],
+                "changed_files": [],
+                "verification": [],
+                "blockers": [],
+                "followups": [],
+                "attachments": ["art_invented"],
+                "confidence": "high"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "cancellation",
       "description": "Cancellation lands while a tool is in flight.",
       "calls": [

--- a/ovim-core/src/agent_runtime/handoff.rs
+++ b/ovim-core/src/agent_runtime/handoff.rs
@@ -10,6 +10,9 @@ use std::collections::BTreeSet;
 use std::fmt;
 
 pub const STRUCTURED_HANDOFF_VERSION: u32 = 1;
+pub const MAX_HANDOFF_ATTACHMENT_BYTES: usize = 1024 * 1024;
+pub const MAX_HANDOFF_ATTACHMENTS: usize = 16;
+pub const MAX_HANDOFF_ATTACHMENT_TOTAL_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -113,7 +116,7 @@ impl Default for HandoffLimits {
             max_verification: 64,
             max_blockers: 32,
             max_followups: 32,
-            max_attachments: 16,
+            max_attachments: MAX_HANDOFF_ATTACHMENTS,
         }
     }
 }
@@ -559,6 +562,7 @@ pub enum HandoffValidationError {
     },
     DuplicatePath(String),
     DuplicateAttachment(ArtifactId),
+    InvalidAttachmentReference(String),
     InvalidEvidenceLine {
         index: usize,
     },
@@ -613,6 +617,9 @@ impl fmt::Display for HandoffValidationError {
             }
             Self::DuplicateAttachment(id) => {
                 write!(formatter, "handoff attachments repeats artifact {id}")
+            }
+            Self::InvalidAttachmentReference(detail) => {
+                write!(formatter, "invalid handoff attachment reference: {detail}")
             }
             Self::InvalidEvidenceLine { index } => {
                 write!(

--- a/ovim-core/src/agent_runtime/handoff.rs
+++ b/ovim-core/src/agent_runtime/handoff.rs
@@ -4,7 +4,7 @@
 //! recording a handoff or treating an agent as complete.
 
 use super::AgentWorkspaceWarning;
-use crate::run_log::RepoPath;
+use crate::run_log::{ArtifactId, RepoPath};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -80,6 +80,8 @@ pub struct StructuredHandoffV1 {
     pub blockers: Vec<String>,
     #[serde(default)]
     pub followups: Vec<String>,
+    #[serde(default)]
+    pub attachments: Vec<ArtifactId>,
     pub confidence: HandoffConfidence,
 }
 
@@ -95,6 +97,7 @@ pub struct HandoffLimits {
     pub max_verification: usize,
     pub max_blockers: usize,
     pub max_followups: usize,
+    pub max_attachments: usize,
 }
 
 impl Default for HandoffLimits {
@@ -110,6 +113,7 @@ impl Default for HandoffLimits {
             max_verification: 64,
             max_blockers: 32,
             max_followups: 32,
+            max_attachments: 16,
         }
     }
 }
@@ -181,6 +185,19 @@ impl HandoffValidator {
             handoff.followups.len(),
             self.limits.max_followups,
         )?;
+        validate_count(
+            "attachments",
+            handoff.attachments.len(),
+            self.limits.max_attachments,
+        )?;
+        let mut attachments = BTreeSet::new();
+        for artifact_id in &handoff.attachments {
+            if !attachments.insert(artifact_id) {
+                return Err(HandoffValidationError::DuplicateAttachment(
+                    artifact_id.clone(),
+                ));
+            }
+        }
 
         for (index, evidence) in handoff.evidence.iter().enumerate() {
             validate_path(
@@ -416,6 +433,7 @@ impl ValidatedHandoff {
                 .collect(),
             blockers: project_text(&self.handoff.blockers, BLOCKERS, TEXT_BYTES),
             followups: project_text(&self.handoff.followups, FOLLOWUPS, TEXT_BYTES),
+            attachments: self.handoff.attachments.clone(),
             omitted_evidence: self.handoff.evidence.len().saturating_sub(EVIDENCE),
             omitted_changed_files: self
                 .handoff
@@ -478,6 +496,8 @@ pub struct ParentHandoffProjection {
     pub verification: Vec<ParentVerificationProjection>,
     pub blockers: Vec<String>,
     pub followups: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<ArtifactId>,
     pub omitted_evidence: usize,
     pub omitted_changed_files: usize,
     pub omitted_verification: usize,
@@ -538,6 +558,7 @@ pub enum HandoffValidationError {
         path: String,
     },
     DuplicatePath(String),
+    DuplicateAttachment(ArtifactId),
     InvalidEvidenceLine {
         index: usize,
     },
@@ -589,6 +610,9 @@ impl fmt::Display for HandoffValidationError {
             ),
             Self::DuplicatePath(path) => {
                 write!(formatter, "handoff changed_files repeats path {path:?}")
+            }
+            Self::DuplicateAttachment(id) => {
+                write!(formatter, "handoff attachments repeats artifact {id}")
             }
             Self::InvalidEvidenceLine { index } => {
                 write!(
@@ -644,6 +668,7 @@ mod tests {
             }],
             blockers: vec![],
             followups: vec!["Wire the supervisor in the next slice.".into()],
+            attachments: vec![],
             confidence: HandoffConfidence::High,
         }
     }
@@ -711,6 +736,23 @@ mod tests {
     }
 
     #[test]
+    fn validates_unique_attachment_handles() {
+        let mut handoff = completed();
+        let attachment = ArtifactId::parse("art_durable_report").unwrap();
+        handoff.attachments.push(attachment.clone());
+        assert!(HandoffValidator::default()
+            .validate(handoff.clone(), None)
+            .is_ok());
+        handoff.attachments.push(attachment.clone());
+        assert_eq!(
+            HandoffValidator::default()
+                .validate(handoff, None)
+                .unwrap_err(),
+            HandoffValidationError::DuplicateAttachment(attachment)
+        );
+    }
+
+    #[test]
     fn accepts_partial_non_completion_but_requires_explicit_blocker() {
         let partial = StructuredHandoffV1 {
             version: 1,
@@ -721,6 +763,7 @@ mod tests {
             verification: vec![],
             blockers: vec!["Child elapsed-time budget was exhausted.".into()],
             followups: vec![],
+            attachments: vec![],
             confidence: HandoffConfidence::Medium,
         };
         assert!(HandoffValidator::default()

--- a/ovim-core/src/agent_runtime/headless.rs
+++ b/ovim-core/src/agent_runtime/headless.rs
@@ -491,6 +491,8 @@ pub struct AgentHandoffSnapshot {
     pub changed_files: Vec<String>,
     pub blockers: Vec<String>,
     pub followups: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<ArtifactId>,
     pub confidence: String,
 }
 
@@ -864,6 +866,7 @@ fn latest_handoffs(events: &[EventEnvelope]) -> BTreeMap<AgentId, AgentHandoffSn
                     changed_files: handoff.changed_files.clone(),
                     blockers: handoff.blockers.clone(),
                     followups: handoff.followups.clone(),
+                    attachments: handoff.attachments.clone(),
                     confidence: format!("{:?}", handoff.confidence).to_lowercase(),
                 },
             ))
@@ -879,10 +882,12 @@ fn artifact_handles_by_agent(
         let Some(agent_id) = &event.agent_id else {
             continue;
         };
-        let EventKind::FileMutation(mutation) = &event.kind else {
-            continue;
+        let artifacts: &[ArtifactRecord] = match &event.kind {
+            EventKind::FileMutation(mutation) => &mutation.artifacts,
+            EventKind::AgentAttachment(attachment) => std::slice::from_ref(&attachment.artifact),
+            _ => continue,
         };
-        for artifact in &mutation.artifacts {
+        for artifact in artifacts {
             result
                 .entry(agent_id.clone())
                 .or_default()
@@ -1131,6 +1136,7 @@ mod tests {
             changed_files: Vec::new(),
             blockers: vec![format!("raw result preserved in event {raw_event_id}")],
             followups: Vec::new(),
+            attachments: Vec::new(),
             confidence: "low".into(),
         };
         let invalid = InvalidHandoffSnapshot {

--- a/ovim-core/src/agent_runtime/loop_runner.rs
+++ b/ovim-core/src/agent_runtime/loop_runner.rs
@@ -482,6 +482,12 @@ pub trait AgentLoopEventSink: Send + Sync {
         &self,
         event: AgentLoopEventRecord,
     ) -> AgentFuture<'_, Result<EventEnvelope, AgentLoopError>>;
+
+    fn validate_handoff_attachments(
+        &self,
+        handle: &DispatchHandle,
+        attachments: &[crate::run_log::ArtifactId],
+    ) -> AgentFuture<'_, Result<(), HandoffValidationError>>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -923,8 +929,22 @@ impl AgentLoopRunner {
                         "provider returned a handoff with a tool still in flight",
                     )
                     .await?;
-                    match input.handoff_validator.validate_json(&payload, None) {
-                        Ok(handoff) => break handoff,
+                    let validation = match input.handoff_validator.validate_json(&payload, None) {
+                        Ok(handoff) => match input
+                            .event_sink
+                            .validate_handoff_attachments(
+                                &input.handle,
+                                &handoff.as_handoff().attachments,
+                            )
+                            .await
+                        {
+                            Ok(()) => break handoff,
+                            Err(error) => Err(error),
+                        },
+                        Err(error) => Err(error),
+                    };
+                    match validation {
+                        Ok(()) => unreachable!("valid handoffs break from the provider loop"),
                         Err(error) => {
                             let preserved =
                                 record_invalid_handoff(&input, &payload, &error, true).await?;
@@ -1573,6 +1593,23 @@ mod tests {
         ) -> AgentFuture<'_, Result<EventEnvelope, AgentLoopError>> {
             Box::pin(async move { self.append(record) })
         }
+
+        fn validate_handoff_attachments(
+            &self,
+            _handle: &DispatchHandle,
+            attachments: &[crate::run_log::ArtifactId],
+        ) -> AgentFuture<'_, Result<(), HandoffValidationError>> {
+            let has_attachments = !attachments.is_empty();
+            Box::pin(async move {
+                if has_attachments {
+                    Err(HandoffValidationError::InvalidAttachmentReference(
+                        "test sink cannot resolve attachments".into(),
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+        }
     }
 
     impl AgentLoopRuntimeHooks for RecordingHarness {
@@ -1947,6 +1984,30 @@ mod tests {
         assert!(!preserved.1.raw_payload.is_empty());
         assert!(preserved.1.repair_attempted);
         assert!(result.handoff.as_handoff().blockers[0].contains(preserved.0.event_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn invented_attachment_handoff_is_preserved_and_fails_validation() {
+        let harness = Arc::new(RecordingHarness::new());
+        let result = AgentLoopRunner::run(input(
+            "invalid_attachment_handoff",
+            harness.clone(),
+            AgentCancellationToken::new(),
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(result.handoff.status(), HandoffStatus::Failed);
+        let events = harness.sink.events(&result_event_run(&harness)).unwrap();
+        let invalid = events
+            .iter()
+            .find_map(|event| match &event.kind {
+                EventKind::AgentHandoffValidationFailed(failed) => Some(failed),
+                _ => None,
+            })
+            .expect("invented attachment handoff must be preserved");
+        assert!(invalid.error.contains("cannot resolve attachments"));
+        assert!(invalid.repair_attempted);
     }
 
     #[tokio::test]

--- a/ovim-core/src/agent_runtime/loop_runner.rs
+++ b/ovim-core/src/agent_runtime/loop_runner.rs
@@ -1417,6 +1417,7 @@ fn synthetic_handoff(
                 verification: Vec::new(),
                 blockers: vec![detail],
                 followups: Vec::new(),
+                attachments: Vec::new(),
                 confidence: HandoffConfidence::Low,
             },
             Some(status),

--- a/ovim-core/src/agent_runtime/mailbox.rs
+++ b/ovim-core/src/agent_runtime/mailbox.rs
@@ -1492,6 +1492,7 @@ mod tests {
                     verification: vec![],
                     blockers: vec![],
                     followups: vec![],
+                    attachments: vec![],
                     confidence: HandoffConfidence::High,
                 },
                 Some(HandoffStatus::Completed),

--- a/ovim-core/src/agent_runtime/profile_provider.rs
+++ b/ovim-core/src/agent_runtime/profile_provider.rs
@@ -399,13 +399,10 @@ impl ProfileAgentSession {
                     "submit_handoff must be the only tool call in its provider round",
                 ));
             }
-            submit_handoff_schema()
-                .validate_instance(&handoff)
-                .map_err(|error| {
-                    AgentProviderError::new(format!(
-                        "submit_handoff arguments failed schema validation: {error}"
-                    ))
-                })?;
+            // Forward the bounded decoded payload to the runner even when the
+            // provider violates the advertised schema. The runner preserves
+            // invalid handoffs durably and can ask this retained session to
+            // repair them; rejecting here used to discard the result entirely.
             if !self.pending_parent_messages.is_empty() {
                 self.messages.push(ChatMessage {
                     role: ChatRole::Assistant,
@@ -645,7 +642,7 @@ impl AgentProviderSession for ProfileAgentSession {
             self.messages.push(ChatMessage {
                 role: ChatRole::User,
                 content: format!(
-                    "Your previous submit_handoff result failed validation. Repair only the result envelope; do not redo the investigation. Preserve every finding and evidence item, correct the schema contradiction, and call submit_handoff exactly once.\n\nValidation error: {}\n\nRejected payload:\n{}",
+                    "Your previous submit_handoff result failed validation. Repair only the result envelope; do not redo the investigation. Preserve every finding and evidence item. If substantial content does not fit the concise summary, call create_handoff_attachment first and reference its artifact_id in submit_handoff.attachments. Then call submit_handoff exactly once in a separate round.\n\nValidation error: {}\n\nRejected payload:\n{}",
                     redact_high_risk_tokens(validation_error),
                     payload
                 ),
@@ -810,9 +807,10 @@ fn submit_handoff_schema() -> crate::ai::tools::StrictJsonSchema {
             },
             "blockers": { "type": "array", "maxItems": 32, "items": { "type": "string", "minLength": 1, "maxLength": 2048 } },
             "followups": { "type": "array", "maxItems": 32, "items": { "type": "string", "minLength": 1, "maxLength": 2048 } },
+            "attachments": { "type": "array", "maxItems": 16, "items": { "type": "string", "pattern": "^art_.+" } },
             "confidence": { "type": "string", "enum": ["low", "medium", "high"] }
         },
-        "required": ["version", "status", "summary", "evidence", "changed_files", "verification", "blockers", "followups", "confidence"]
+        "required": ["version", "status", "summary", "evidence", "changed_files", "verification", "blockers", "followups", "attachments", "confidence"]
     }))
     .expect("submit_handoff schema is static and strict")
 }
@@ -1160,6 +1158,7 @@ mod tests {
             "verification": [],
             "blockers": [],
             "followups": [],
+            "attachments": [],
             "confidence": "high"
         })
     }
@@ -1234,6 +1233,37 @@ mod tests {
         assert!(repair_prompt.contains("Repair only the result envelope"));
         assert!(repair_prompt.contains("completed handoff cannot contain blockers"));
         assert!(repair_prompt.contains("verification unavailable"));
+        assert!(repair_prompt.contains("create_handoff_attachment"));
+    }
+
+    #[tokio::test]
+    async fn oversized_handoff_reaches_runner_for_durable_repair() {
+        let mut oversized = completed_handoff();
+        oversized["summary"] = json!("x".repeat(4097));
+        let transport = Arc::new(ScriptedTransport::new([RoundScript {
+            chunks: vec![
+                ScriptChunk::Tool {
+                    id: "oversized",
+                    name: SUBMIT_HANDOFF_TOOL,
+                    arguments: oversized.clone(),
+                },
+                ScriptChunk::Done,
+            ],
+            error: None,
+        }]));
+        let adapter = provider(AiProviderKind::OpenAi, transport);
+        let mut session = adapter
+            .start(start_request(
+                AiProviderKind::OpenAi,
+                vec![scoped_read_tool()],
+            ))
+            .await
+            .unwrap();
+        let payload = next_handoff(&mut session).await;
+        assert_eq!(
+            serde_json::from_slice::<Value>(&payload).unwrap(),
+            oversized
+        );
     }
 
     #[tokio::test]

--- a/ovim-core/src/agent_runtime/profile_provider.rs
+++ b/ovim-core/src/agent_runtime/profile_provider.rs
@@ -8,7 +8,8 @@
 use super::{
     AgentFuture, AgentProviderAdapter, AgentProviderError, AgentProviderEvent,
     AgentProviderFollowup, AgentProviderSession, AgentProviderStart, AgentToolResult,
-    DelegationEnvelope, ProviderBinding, ScopedTool,
+    DelegationEnvelope, ProviderBinding, ScopedTool, MAX_HANDOFF_ATTACHMENTS,
+    MAX_HANDOFF_ATTACHMENT_BYTES,
 };
 use crate::ai::{
     redact_high_risk_tokens, AiConfig, AiProfileConfig, AiProviderKind, ApiKeyConfig, ChatMessage,
@@ -26,6 +27,7 @@ pub const SUBMIT_HANDOFF_TOOL: &str = "submit_handoff";
 pub const MAX_DELEGATION_SYSTEM_PROMPT_BYTES: usize = 32 * 1024;
 const MAX_PROVIDER_CONTENT_BYTES: usize = 128 * 1024;
 const MAX_TOOL_ARGUMENT_BYTES: usize = 64 * 1024;
+const MAX_ATTACHMENT_TOOL_ARGUMENT_BYTES: usize = MAX_HANDOFF_ATTACHMENT_BYTES + 4 * 1024;
 
 /// One independently owned request to the shared streaming transport.
 ///
@@ -807,7 +809,7 @@ fn submit_handoff_schema() -> crate::ai::tools::StrictJsonSchema {
             },
             "blockers": { "type": "array", "maxItems": 32, "items": { "type": "string", "minLength": 1, "maxLength": 2048 } },
             "followups": { "type": "array", "maxItems": 32, "items": { "type": "string", "minLength": 1, "maxLength": 2048 } },
-            "attachments": { "type": "array", "maxItems": 16, "items": { "type": "string", "pattern": "^art_.+" } },
+            "attachments": { "type": "array", "maxItems": MAX_HANDOFF_ATTACHMENTS, "items": { "type": "string", "pattern": "^art_.+" } },
             "confidence": { "type": "string", "enum": ["low", "medium", "high"] }
         },
         "required": ["version", "status", "summary", "evidence", "changed_files", "verification", "blockers", "followups", "attachments", "confidence"]
@@ -919,9 +921,14 @@ fn validate_tool_call_shape(
     let bytes = serde_json::to_vec(arguments)
         .map_err(|error| AgentProviderError::new(error.to_string()))?
         .len();
-    if bytes > MAX_TOOL_ARGUMENT_BYTES {
+    let maximum = if name == crate::ai::tools::subagents::CREATE_HANDOFF_ATTACHMENT_TOOL {
+        MAX_ATTACHMENT_TOOL_ARGUMENT_BYTES
+    } else {
+        MAX_TOOL_ARGUMENT_BYTES
+    };
+    if bytes > maximum {
         return Err(AgentProviderError::new(format!(
-            "provider arguments for tool {name:?} exceeded {MAX_TOOL_ARGUMENT_BYTES} bytes"
+            "provider arguments for tool {name:?} exceeded {maximum} bytes"
         )));
     }
     Ok(())
@@ -1264,6 +1271,36 @@ mod tests {
             serde_json::from_slice::<Value>(&payload).unwrap(),
             oversized
         );
+    }
+
+    #[test]
+    fn attachment_tool_has_its_own_bounded_transport_ceiling() {
+        let at_limit = json!({
+            "name": "report.md",
+            "media_type": "text/markdown",
+            "content": "x".repeat(MAX_HANDOFF_ATTACHMENT_BYTES),
+        });
+        assert!(validate_tool_call_shape(
+            "attachment",
+            crate::ai::tools::subagents::CREATE_HANDOFF_ATTACHMENT_TOOL,
+            &at_limit,
+        )
+        .is_ok());
+
+        let ordinary = json!({ "content": "x".repeat(MAX_TOOL_ARGUMENT_BYTES) });
+        assert!(validate_tool_call_shape("ordinary", "read_snapshot", &ordinary).is_err());
+
+        let too_large = json!({
+            "name": "report.md",
+            "media_type": "text/markdown",
+            "content": "x".repeat(MAX_ATTACHMENT_TOOL_ARGUMENT_BYTES),
+        });
+        assert!(validate_tool_call_shape(
+            "attachment",
+            crate::ai::tools::subagents::CREATE_HANDOFF_ATTACHMENT_TOOL,
+            &too_large,
+        )
+        .is_err());
     }
 
     #[tokio::test]

--- a/ovim-core/src/agent_runtime/profile_provider.rs
+++ b/ovim-core/src/agent_runtime/profile_provider.rs
@@ -27,7 +27,10 @@ pub const SUBMIT_HANDOFF_TOOL: &str = "submit_handoff";
 pub const MAX_DELEGATION_SYSTEM_PROMPT_BYTES: usize = 32 * 1024;
 const MAX_PROVIDER_CONTENT_BYTES: usize = 128 * 1024;
 const MAX_TOOL_ARGUMENT_BYTES: usize = 64 * 1024;
-const MAX_ATTACHMENT_TOOL_ARGUMENT_BYTES: usize = MAX_HANDOFF_ATTACHMENT_BYTES + 4 * 1024;
+// JSON may encode each raw content byte as a six-byte `\u00XX` escape. Keep a
+// bounded transport envelope without making escaping reduce the documented raw
+// attachment capacity.
+const MAX_ATTACHMENT_TOOL_ARGUMENT_BYTES: usize = MAX_HANDOFF_ATTACHMENT_BYTES * 6 + 4 * 1024;
 
 /// One independently owned request to the shared streaming transport.
 ///
@@ -918,6 +921,15 @@ fn validate_tool_call_shape(
             "provider emitted non-object arguments for tool {name:?}"
         )));
     }
+    if name == crate::ai::tools::subagents::CREATE_HANDOFF_ATTACHMENT_TOOL {
+        if let Some(content) = arguments.get("content").and_then(Value::as_str) {
+            if content.len() > MAX_HANDOFF_ATTACHMENT_BYTES {
+                return Err(AgentProviderError::new(format!(
+                    "provider attachment content exceeded {MAX_HANDOFF_ATTACHMENT_BYTES} raw UTF-8 bytes"
+                )));
+            }
+        }
+    }
     let bytes = serde_json::to_vec(arguments)
         .map_err(|error| AgentProviderError::new(error.to_string()))?
         .len();
@@ -1274,18 +1286,25 @@ mod tests {
     }
 
     #[test]
-    fn attachment_tool_has_its_own_bounded_transport_ceiling() {
-        let at_limit = json!({
-            "name": "report.md",
-            "media_type": "text/markdown",
-            "content": "x".repeat(MAX_HANDOFF_ATTACHMENT_BYTES),
-        });
-        assert!(validate_tool_call_shape(
-            "attachment",
-            crate::ai::tools::subagents::CREATE_HANDOFF_ATTACHMENT_TOOL,
-            &at_limit,
-        )
-        .is_ok());
+    fn attachment_transport_limit_measures_raw_utf8_content() {
+        for content in [
+            "x".repeat(MAX_HANDOFF_ATTACHMENT_BYTES),
+            "\0".repeat(MAX_HANDOFF_ATTACHMENT_BYTES),
+            "\\\"".repeat(MAX_HANDOFF_ATTACHMENT_BYTES / 2),
+            "å".repeat(MAX_HANDOFF_ATTACHMENT_BYTES / 2),
+        ] {
+            let at_limit = json!({
+                "name": "report.md",
+                "media_type": "text/markdown",
+                "content": content,
+            });
+            assert!(validate_tool_call_shape(
+                "attachment",
+                crate::ai::tools::subagents::CREATE_HANDOFF_ATTACHMENT_TOOL,
+                &at_limit,
+            )
+            .is_ok());
+        }
 
         let ordinary = json!({ "content": "x".repeat(MAX_TOOL_ARGUMENT_BYTES) });
         assert!(validate_tool_call_shape("ordinary", "read_snapshot", &ordinary).is_err());
@@ -1293,7 +1312,7 @@ mod tests {
         let too_large = json!({
             "name": "report.md",
             "media_type": "text/markdown",
-            "content": "x".repeat(MAX_ATTACHMENT_TOOL_ARGUMENT_BYTES),
+            "content": "å".repeat(MAX_HANDOFF_ATTACHMENT_BYTES / 2 + 1),
         });
         assert!(validate_tool_call_shape(
             "attachment",

--- a/ovim-core/src/agent_runtime/supervisor.rs
+++ b/ovim-core/src/agent_runtime/supervisor.rs
@@ -1065,6 +1065,20 @@ impl AgentLoopEventSink for SchedulerLoopBridge {
                 .map_err(|error| AgentLoopError::EventSink(error.to_string()))
         })
     }
+
+    fn validate_handoff_attachments(
+        &self,
+        handle: &DispatchHandle,
+        attachments: &[crate::run_log::ArtifactId],
+    ) -> super::AgentFuture<'_, Result<(), super::HandoffValidationError>> {
+        let result = self
+            .scheduler
+            .lock()
+            .map_err(|_| "scheduler lock poisoned".to_string())
+            .and_then(|scheduler| scheduler.validate_handoff_attachments(handle, attachments))
+            .map_err(super::HandoffValidationError::InvalidAttachmentReference);
+        Box::pin(async move { result })
+    }
 }
 
 impl AgentLoopRuntimeHooks for SchedulerLoopBridge {

--- a/ovim-core/src/ai/tools/subagents.rs
+++ b/ovim-core/src/ai/tools/subagents.rs
@@ -3,6 +3,7 @@
 use super::{SideEffect, StrictJsonSchema, ToolDefinition, ToolSchemaError};
 use crate::agent_runtime::{
     AgentCapability, DelegatedAgentPolicy, ScopedTool, SubagentModelCatalog,
+    MAX_HANDOFF_ATTACHMENT_BYTES,
 };
 use crate::ai::{FileScope, RequiredScope};
 use crate::run_log::ToolSideEffect;
@@ -40,8 +41,8 @@ pub fn attachment_tools() -> Result<Vec<ToolDefinition>, ToolSchemaError> {
                 "type": "object", "additionalProperties": false,
                 "properties": {
                     "name": { "type": "string", "minLength": 1, "maxLength": 255 },
-                    "media_type": { "type": "string", "minLength": 1, "maxLength": 127 },
-                    "content": { "type": "string", "minLength": 1, "maxLength": 1048576 }
+                    "media_type": { "type": "string", "minLength": 3, "maxLength": 127, "pattern": "^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$" },
+                    "content": { "type": "string", "minLength": 1, "maxLength": MAX_HANDOFF_ATTACHMENT_BYTES }
                 },
                 "required": ["name", "media_type", "content"]
             }))?,

--- a/ovim-core/src/ai/tools/subagents.rs
+++ b/ovim-core/src/ai/tools/subagents.rs
@@ -15,6 +15,8 @@ pub const WAIT_AGENT_TOOL: &str = "wait_agent";
 pub const INTERRUPT_AGENT_TOOL: &str = "interrupt_agent";
 pub const SEND_MESSAGE_TOOL: &str = "send_message";
 pub const FOLLOWUP_AGENT_TOOL: &str = "followup_agent";
+pub const CREATE_HANDOFF_ATTACHMENT_TOOL: &str = "create_handoff_attachment";
+pub const READ_HANDOFF_ATTACHMENT_TOOL: &str = "read_handoff_attachment";
 
 pub fn is_parent_control_tool(name: &str) -> bool {
     matches!(
@@ -25,7 +27,53 @@ pub fn is_parent_control_tool(name: &str) -> bool {
             | INTERRUPT_AGENT_TOOL
             | SEND_MESSAGE_TOOL
             | FOLLOWUP_AGENT_TOOL
+            | READ_HANDOFF_ATTACHMENT_TOOL
     )
+}
+
+pub fn attachment_tools() -> Result<Vec<ToolDefinition>, ToolSchemaError> {
+    Ok(vec![
+        definition(
+            CREATE_HANDOFF_ATTACHMENT_TOOL,
+            "Persist substantial handoff content as a durable run artifact before submit_handoff. Return the artifact_id in submit_handoff.attachments; keep the handoff summary concise.".into(),
+            strict(json!({
+                "type": "object", "additionalProperties": false,
+                "properties": {
+                    "name": { "type": "string", "minLength": 1, "maxLength": 255 },
+                    "media_type": { "type": "string", "minLength": 1, "maxLength": 127 },
+                    "content": { "type": "string", "minLength": 1, "maxLength": 1048576 }
+                },
+                "required": ["name", "media_type", "content"]
+            }))?,
+        ),
+        definition(
+            READ_HANDOFF_ATTACHMENT_TOOL,
+            "Read one durable attachment created by this agent or one of its descendants.".into(),
+            strict(json!({
+                "type": "object", "additionalProperties": false,
+                "properties": { "artifact_id": { "type": "string", "pattern": "^art_.+" } },
+                "required": ["artifact_id"]
+            }))?,
+        ),
+    ])
+}
+
+pub fn delegated_attachment_tools() -> Result<Vec<ScopedTool>, ToolSchemaError> {
+    attachment_tools()?
+        .into_iter()
+        .map(|definition| {
+            Ok(ScopedTool {
+                name: definition.name,
+                description: definition.description,
+                input_schema: definition
+                    .custom_input_schema
+                    .expect("attachment schema is strict"),
+                side_effect: ToolSideEffect::Read,
+                required_capability: AgentCapability::Read,
+                requires_approval: false,
+            })
+        })
+        .collect()
 }
 
 pub fn parent_control_tools(

--- a/ovim-core/src/editor/ai_subagents.rs
+++ b/ovim-core/src/editor/ai_subagents.rs
@@ -19,16 +19,20 @@ use crate::agent_runtime::{
 };
 use crate::ai::chat_types::ToolCallInfo;
 use crate::ai::tools::subagents::{
-    delegated_parent_control_tools, is_parent_control_tool, FOLLOWUP_AGENT_TOOL,
-    INTERRUPT_AGENT_TOOL, LIST_AGENTS_TOOL, SEND_MESSAGE_TOOL, SPAWN_AGENT_TOOL, WAIT_AGENT_TOOL,
+    attachment_tools, delegated_attachment_tools, delegated_parent_control_tools,
+    is_parent_control_tool, CREATE_HANDOFF_ATTACHMENT_TOOL, FOLLOWUP_AGENT_TOOL,
+    INTERRUPT_AGENT_TOOL, LIST_AGENTS_TOOL, READ_HANDOFF_ATTACHMENT_TOOL, SEND_MESSAGE_TOOL,
+    SPAWN_AGENT_TOOL, WAIT_AGENT_TOOL,
 };
 use crate::ai::tools::ToolDefinition;
 use crate::ai::tools::ToolResult;
 use crate::ai::AiConfig;
 use crate::run_log::{
-    AgentId, ArtifactStore, BaseManifest, BaseManifestId, EventActor, EventId, EventKind,
-    LocalRunStore, ManifestId, NewRunEvent, OperationId, RepoPath, RepositoryId, RunEventSink,
-    RunId, TurnId, WorkspaceId,
+    AgentAttachmentEvent, AgentId, ArtifactExportPolicy, ArtifactId, ArtifactRecord,
+    ArtifactRetention, ArtifactSource, ArtifactState, ArtifactStore, BaseManifest, BaseManifestId,
+    ContentRepresentation, EventActor, EventId, EventKind, LocalRunStore, ManifestId, NewRunEvent,
+    OperationId, RepoPath, RepositoryId, RunEventSink, RunId, TurnId, WorkspaceId,
+    AGENT_ATTACHMENT_EVENT_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -314,11 +318,18 @@ impl AiSubagentService {
     }
 
     pub fn parent_tools(&self) -> Result<Vec<ToolDefinition>, String> {
-        crate::ai::tools::subagents::parent_control_tools(
+        let mut tools = crate::ai::tools::subagents::parent_control_tools(
             self.catalog()?.as_ref(),
             &self.startup_policy,
         )
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string())?;
+        tools.extend(
+            attachment_tools()
+                .map_err(|error| error.to_string())?
+                .into_iter()
+                .filter(|tool| tool.name == READ_HANDOFF_ATTACHMENT_TOOL),
+        );
+        Ok(tools)
     }
 
     pub fn parent_capabilities(&self) -> BTreeSet<AgentCapability> {
@@ -654,15 +665,19 @@ impl AiSubagentRun {
 
 impl AgentToolExtension for EditorAgentToolExtension {
     fn scoped_tools(&self, dispatch: &AgentDispatchRecord) -> Result<Vec<ScopedTool>, String> {
+        let mut tools = delegated_attachment_tools().map_err(|error| error.to_string())?;
         if !dispatch
             .role
             .capabilities
             .contains(&AgentCapability::DispatchAgents)
         {
-            return Ok(Vec::new());
+            return Ok(tools);
         }
-        delegated_parent_control_tools(self.catalog.as_ref(), &self.policy)
-            .map_err(|error| error.to_string())
+        tools.extend(
+            delegated_parent_control_tools(self.catalog.as_ref(), &self.policy)
+                .map_err(|error| error.to_string())?,
+        );
+        Ok(tools)
     }
 
     fn execute(
@@ -678,6 +693,10 @@ impl AgentToolExtension for EditorAgentToolExtension {
                 SEND_MESSAGE_TOOL => run.send_nested_agent_message(&call),
                 FOLLOWUP_AGENT_TOOL => run.followup_nested_agent(&call, &self.policy).await,
                 INTERRUPT_AGENT_TOOL => run.interrupt_nested_agent(&call).await,
+                CREATE_HANDOFF_ATTACHMENT_TOOL => run.create_handoff_attachment(&call),
+                READ_HANDOFF_ATTACHMENT_TOOL => {
+                    run.read_handoff_attachment(&call.handle.agent_id, &call.arguments)
+                }
                 _ => Err(format!(
                     "{} is not a delegated coordination tool",
                     call.tool_name
@@ -690,6 +709,126 @@ impl AgentToolExtension for EditorAgentToolExtension {
 }
 
 impl AiSubagentRun {
+    fn create_handoff_attachment(&self, call: &AgentToolCall) -> Result<serde_json::Value, String> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Arguments {
+            name: String,
+            media_type: String,
+            content: String,
+        }
+        const MAX_ATTACHMENT_BYTES: usize = 1024 * 1024;
+        let args: Arguments =
+            serde_json::from_value(call.arguments.clone()).map_err(|error| error.to_string())?;
+        if args.name.trim().is_empty() || args.name.contains('/') || args.name.contains('\\') {
+            return Err("attachment name must be a non-empty file name".into());
+        }
+        if args.content.len() > MAX_ATTACHMENT_BYTES {
+            return Err(format!(
+                "attachment is {} bytes, maximum is {MAX_ATTACHMENT_BYTES}",
+                args.content.len()
+            ));
+        }
+        let stored = self
+            .artifact_store
+            .put_bytes(args.content.as_bytes())
+            .map_err(|error| error.to_string())?;
+        let artifact = ArtifactRecord {
+            artifact_id: ArtifactId::new(),
+            state: ArtifactState::Available {
+                blob_id: stored.blob_id,
+                byte_len: stored.byte_len,
+            },
+            source: ArtifactSource::Imported {
+                label: Some(args.name.clone()),
+            },
+            representation: ContentRepresentation::EditorText {
+                encoding: Some("utf-8".into()),
+                line_endings: None,
+            },
+            media_type: Some(args.media_type.clone()),
+            retention: ArtifactRetention::Run,
+            export_policy: ArtifactExportPolicy::Include,
+        };
+        self.store
+            .append(NewRunEvent {
+                run_id: self.run_id.clone(),
+                caused_by: Some(call.caused_by_event.clone()),
+                operation_id: None,
+                provider_call_id: None,
+                actor: EventActor::Agent(call.handle.agent_id.clone()),
+                agent_id: Some(call.handle.agent_id.clone()),
+                turn_id: call.causing_turn_id.clone(),
+                workspace_id: Some(call.handle.workspace.workspace_id.clone()),
+                branch_id: None,
+                kind: EventKind::AgentAttachment(AgentAttachmentEvent {
+                    version: AGENT_ATTACHMENT_EVENT_VERSION,
+                    name: args.name.clone(),
+                    artifact: artifact.clone(),
+                }),
+            })
+            .map_err(|error| error.to_string())?;
+        Ok(
+            json!({ "artifact_id": artifact.artifact_id, "name": args.name,
+            "media_type": args.media_type, "byte_len": stored.byte_len }),
+        )
+    }
+
+    fn read_handoff_attachment(
+        &self,
+        reader: &AgentId,
+        arguments: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Arguments {
+            artifact_id: ArtifactId,
+        }
+        let args: Arguments =
+            serde_json::from_value(arguments.clone()).map_err(|error| error.to_string())?;
+        let events = self
+            .store
+            .events(&self.run_id)
+            .map_err(|error| error.to_string())?;
+        let (owner, attachment) = events
+            .iter()
+            .find_map(|event| match &event.kind {
+                EventKind::AgentAttachment(value)
+                    if value.artifact.artifact_id == args.artifact_id =>
+                {
+                    event.agent_id.as_ref().map(|owner| (owner, value))
+                }
+                _ => None,
+            })
+            .ok_or_else(|| format!("unknown handoff attachment {}", args.artifact_id))?;
+        let records = self
+            .supervisor
+            .dispatches()
+            .map_err(|error| error.to_string())?;
+        let authorized = reader == &self.root_agent_id
+            || reader == owner
+            || records
+                .iter()
+                .find(|record| &record.handle.agent_id == owner)
+                .is_some_and(|record| record.parent_agent_id.as_ref() == Some(reader));
+        if !authorized {
+            return Err("attachment is not owned by this agent or a direct child".into());
+        }
+        let ArtifactState::Available { blob_id, .. } = attachment.artifact.state else {
+            return Err("attachment content is unavailable".into());
+        };
+        let bytes = self
+            .artifact_store
+            .read(blob_id)
+            .map_err(|error| error.to_string())?;
+        let content =
+            String::from_utf8(bytes).map_err(|_| "attachment is not UTF-8 text".to_string())?;
+        Ok(
+            json!({ "artifact_id": args.artifact_id, "name": attachment.name,
+            "media_type": attachment.artifact.media_type, "content": content }),
+        )
+    }
+
     fn spawn_nested_agent(
         &self,
         call: &AgentToolCall,
@@ -1773,6 +1912,7 @@ impl Editor {
         let result = match call.name.as_str() {
             SPAWN_AGENT_TOOL => self.spawn_ai_subagent(&call.arguments),
             LIST_AGENTS_TOOL => self.list_ai_subagents(),
+            READ_HANDOFF_ATTACHMENT_TOOL => self.read_ai_handoff_attachment(&call.arguments),
             SEND_MESSAGE_TOOL => self.send_ai_subagent_message(&call.arguments),
             FOLLOWUP_AGENT_TOOL => Err(
                 "followup_agent is asynchronous and must be dispatched through the editor turn loop"
@@ -2604,6 +2744,21 @@ impl Editor {
         }))
     }
 
+    fn read_ai_handoff_attachment(
+        &self,
+        arguments: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let root = self.active_subagent_root()?;
+        let run = self.ai_state.subagents.run(
+            root.store,
+            root.run_id,
+            root.root_agent_id.clone(),
+            root.repository_id,
+            root.repository_root,
+        )?;
+        run.read_handoff_attachment(&root.root_agent_id, arguments)
+    }
+
     fn capture_snapshot_symbols(&self, repository_root: &Path) -> Vec<SnapshotSymbol> {
         let Some(path) = self.buffer().file_path().map(Path::new) else {
             return Vec::new();
@@ -3280,6 +3435,7 @@ mod tests {
                 INTERRUPT_AGENT_TOOL.into(),
                 SEND_MESSAGE_TOOL.into(),
                 FOLLOWUP_AGENT_TOOL.into(),
+                READ_HANDOFF_ATTACHMENT_TOOL.into(),
             ])
         );
     }
@@ -3377,6 +3533,8 @@ mod tests {
         for required in [
             crate::agent_runtime::SNAPSHOT_SEARCH_SYMBOLS_TOOL,
             crate::agent_runtime::SNAPSHOT_READ_DIAGNOSTICS_TOOL,
+            CREATE_HANDOFF_ATTACHMENT_TOOL,
+            READ_HANDOFF_ATTACHMENT_TOOL,
         ] {
             assert!(child_tools.iter().any(|name| name == required));
         }
@@ -3438,6 +3596,55 @@ mod tests {
             )
             .is_err());
         editor.consume_ai_subagent_updates(&payload).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn child_attachment_is_durable_and_readable_by_root() {
+        let (_repository, _storage, mut editor) = enabled_editor();
+        attach_root_turn(&mut editor);
+        let ToolResult::Success(_) =
+            editor.execute_ai_subagent_control_tool(&spawn_call("attach_report"))
+        else {
+            panic!("spawn should succeed")
+        };
+        let run = editor
+            .ai_state
+            .subagents
+            .runs
+            .lock()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap()
+            .clone();
+        let dispatch = run.supervisor.dispatches().unwrap().remove(0);
+        let cause = run
+            .store
+            .events(&run.run_id)
+            .unwrap()
+            .into_iter()
+            .rev()
+            .find(|event| event.agent_id.as_ref() == Some(&dispatch.handle.agent_id))
+            .unwrap();
+        let input = run.input_factory.build(&dispatch).unwrap();
+        let result = input.tool_executor.execute(AgentToolCall {
+            handle: dispatch.handle.clone(), causing_turn_id: dispatch.causing_turn_id.clone(),
+            caused_by_event: cause.event_id, tool_call_id: "attachment-call".into(),
+            tool_name: CREATE_HANDOFF_ATTACHMENT_TOOL.into(),
+            arguments: json!({"name":"review.md","media_type":"text/markdown","content":"# Durable review\nDetails"}),
+            workspace: input.workspace,
+        }).await.unwrap();
+        let artifact_id = result.result.unwrap()["artifact_id"].clone();
+        let root_id = run.root_agent_id.clone();
+        let read = run
+            .read_handoff_attachment(&root_id, &json!({"artifact_id": artifact_id}))
+            .unwrap();
+        assert_eq!(read["name"], "review.md");
+        assert_eq!(read["content"], "# Durable review\nDetails");
+        let events = run.store.events(&run.run_id).unwrap();
+        assert!(events
+            .iter()
+            .any(|event| matches!(event.kind, EventKind::AgentAttachment(_))));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/ovim-core/src/editor/ai_subagents.rs
+++ b/ovim-core/src/editor/ai_subagents.rs
@@ -15,7 +15,8 @@ use crate::agent_runtime::{
     DispatchRequest, FollowupAgentRequest, ModelFallbackPolicy, ProfileAgentProvider,
     ReasoningEffort, RequestedModelRoute, ScopedTool, SendAgentMessageRequest,
     SnapshotAgentLoopInputFactory, SnapshotDiagnostic, SnapshotSymbol, SubagentModelCatalog,
-    WorkspaceAssignment, WorkspacePolicy, WorkspaceStrategy,
+    WorkspaceAssignment, WorkspacePolicy, WorkspaceStrategy, MAX_HANDOFF_ATTACHMENTS,
+    MAX_HANDOFF_ATTACHMENT_BYTES, MAX_HANDOFF_ATTACHMENT_TOTAL_BYTES,
 };
 use crate::ai::chat_types::ToolCallInfo;
 use crate::ai::tools::subagents::{
@@ -717,18 +718,45 @@ impl AiSubagentRun {
             media_type: String,
             content: String,
         }
-        const MAX_ATTACHMENT_BYTES: usize = 1024 * 1024;
         let args: Arguments =
             serde_json::from_value(call.arguments.clone()).map_err(|error| error.to_string())?;
         if args.name.trim().is_empty() || args.name.contains('/') || args.name.contains('\\') {
             return Err("attachment name must be a non-empty file name".into());
         }
-        if args.content.len() > MAX_ATTACHMENT_BYTES {
+        if !valid_media_type(&args.media_type) {
+            return Err(
+                "attachment media_type must be a normalized IANA-style type/subtype".into(),
+            );
+        }
+        if args.content.len() > MAX_HANDOFF_ATTACHMENT_BYTES {
             return Err(format!(
-                "attachment is {} bytes, maximum is {MAX_ATTACHMENT_BYTES}",
+                "attachment is {} bytes, maximum is {MAX_HANDOFF_ATTACHMENT_BYTES}",
                 args.content.len()
             ));
         }
+        let events = self
+            .store
+            .events(&self.run_id)
+            .map_err(|error| error.to_string())?;
+        let owned = events
+            .iter()
+            .filter_map(|event| match &event.kind {
+                EventKind::AgentAttachment(attachment)
+                    if event.agent_id.as_ref() == Some(&call.handle.agent_id) =>
+                {
+                    Some(attachment)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let prior_bytes = owned
+            .iter()
+            .filter_map(|attachment| match attachment.artifact.state {
+                ArtifactState::Available { byte_len, .. } => Some(byte_len),
+                _ => None,
+            })
+            .sum::<u64>();
+        validate_attachment_budget(owned.len(), prior_bytes, args.content.len())?;
         let stored = self
             .artifact_store
             .put_bytes(args.content.as_bytes())
@@ -739,8 +767,8 @@ impl AiSubagentRun {
                 blob_id: stored.blob_id,
                 byte_len: stored.byte_len,
             },
-            source: ArtifactSource::Imported {
-                label: Some(args.name.clone()),
+            source: ArtifactSource::AgentHandoff {
+                name: args.name.clone(),
             },
             representation: ContentRepresentation::EditorText {
                 encoding: Some("utf-8".into()),
@@ -1196,6 +1224,44 @@ impl AiSubagentRun {
             .map_err(|error| error.to_string())?;
         Ok(json!({ "outcome": "interrupted", "agent_ids": interrupted }))
     }
+}
+
+fn validate_attachment_budget(
+    existing_count: usize,
+    existing_bytes: u64,
+    requested_bytes: usize,
+) -> Result<(), String> {
+    if existing_count >= MAX_HANDOFF_ATTACHMENTS {
+        return Err(format!(
+            "agent already created the maximum of {MAX_HANDOFF_ATTACHMENTS} handoff attachments"
+        ));
+    }
+    let requested_bytes = u64::try_from(requested_bytes)
+        .map_err(|_| "attachment size does not fit durable accounting".to_string())?;
+    let total_limit =
+        u64::try_from(MAX_HANDOFF_ATTACHMENT_TOTAL_BYTES).expect("attachment total limit fits u64");
+    if existing_bytes.saturating_add(requested_bytes) > total_limit {
+        return Err(format!(
+            "agent handoff attachments would exceed the {MAX_HANDOFF_ATTACHMENT_TOTAL_BYTES}-byte total limit"
+        ));
+    }
+    Ok(())
+}
+
+fn valid_media_type(value: &str) -> bool {
+    fn token(value: &str) -> bool {
+        !value.is_empty()
+            && value.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric()
+                    || matches!(
+                        byte,
+                        b'!' | b'#' | b'$' | b'&' | b'^' | b'_' | b'.' | b'+' | b'-'
+                    )
+            })
+    }
+    value
+        .split_once('/')
+        .is_some_and(|(kind, subtype)| token(kind) && token(subtype))
 }
 
 fn agent_record_depth(
@@ -3341,6 +3407,21 @@ mod tests {
     }
 
     #[test]
+    fn attachment_budget_enforces_count_and_cumulative_bytes() {
+        assert!(validate_attachment_budget(0, 0, MAX_HANDOFF_ATTACHMENT_BYTES).is_ok());
+        assert!(validate_attachment_budget(MAX_HANDOFF_ATTACHMENTS, 0, 1)
+            .unwrap_err()
+            .contains("maximum"));
+        assert!(validate_attachment_budget(
+            8,
+            u64::try_from(MAX_HANDOFF_ATTACHMENT_TOTAL_BYTES).unwrap(),
+            1,
+        )
+        .unwrap_err()
+        .contains("total limit"));
+    }
+
+    #[test]
     fn idle_service_rebuilds_after_profile_merge() {
         let mut config = AiConfig::default();
         let mut service = AiSubagentService::new(&config);
@@ -3629,7 +3710,7 @@ mod tests {
         let input = run.input_factory.build(&dispatch).unwrap();
         let result = input.tool_executor.execute(AgentToolCall {
             handle: dispatch.handle.clone(), causing_turn_id: dispatch.causing_turn_id.clone(),
-            caused_by_event: cause.event_id, tool_call_id: "attachment-call".into(),
+            caused_by_event: cause.event_id.clone(), tool_call_id: "attachment-call".into(),
             tool_name: CREATE_HANDOFF_ATTACHMENT_TOOL.into(),
             arguments: json!({"name":"review.md","media_type":"text/markdown","content":"# Durable review\nDetails"}),
             workspace: input.workspace,
@@ -3645,6 +3726,38 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| matches!(event.kind, EventKind::AgentAttachment(_))));
+        drop(events);
+
+        for index in 1..MAX_HANDOFF_ATTACHMENTS {
+            run.create_handoff_attachment(&AgentToolCall {
+                handle: dispatch.handle.clone(),
+                causing_turn_id: dispatch.causing_turn_id.clone(),
+                caused_by_event: cause.event_id.clone(),
+                tool_call_id: format!("attachment-{index}"),
+                tool_name: CREATE_HANDOFF_ATTACHMENT_TOOL.into(),
+                arguments: json!({
+                    "name": format!("report-{index}.md"),
+                    "media_type": "text/markdown",
+                    "content": "bounded",
+                }),
+                workspace: run.input_factory.build(&dispatch).unwrap().workspace,
+            })
+            .unwrap();
+        }
+        let overflow = run.create_handoff_attachment(&AgentToolCall {
+            handle: dispatch.handle.clone(),
+            causing_turn_id: dispatch.causing_turn_id.clone(),
+            caused_by_event: cause.event_id,
+            tool_call_id: "attachment-overflow".into(),
+            tool_name: CREATE_HANDOFF_ATTACHMENT_TOOL.into(),
+            arguments: json!({
+                "name": "overflow.md",
+                "media_type": "text/markdown",
+                "content": "too many",
+            }),
+            workspace: run.input_factory.build(&dispatch).unwrap().workspace,
+        });
+        assert!(overflow.unwrap_err().contains("maximum"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/ovim-core/src/run_log/artifact.rs
+++ b/ovim-core/src/run_log/artifact.rs
@@ -198,6 +198,9 @@ pub enum ArtifactSource {
     Message {
         event_id: EventId,
     },
+    AgentHandoff {
+        name: String,
+    },
     Imported {
         label: Option<String>,
     },

--- a/ovim-core/src/run_log/event.rs
+++ b/ovim-core/src/run_log/event.rs
@@ -23,6 +23,15 @@ pub enum EventActor {
 }
 
 pub const AGENT_HANDOFF_VALIDATION_FAILED_EVENT_VERSION: u32 = 1;
+pub const AGENT_ATTACHMENT_EVENT_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentAttachmentEvent {
+    pub version: u32,
+    pub name: String,
+    pub artifact: super::ArtifactRecord,
+}
 
 /// A provider completed its investigation but returned a result envelope that
 /// failed validation. The bounded original payload is retained so validation
@@ -141,6 +150,7 @@ pub enum EventKind {
     AgentProgress(AgentProgressEvent),
     AgentHandoff(AgentHandoffEvent),
     AgentHandoffValidationFailed(AgentHandoffValidationFailedEvent),
+    AgentAttachment(AgentAttachmentEvent),
     AgentFollowup(AgentFollowupEvent),
     AgentApprovalRequested(AgentApprovalRequestedEvent),
     AgentApprovalResolved(AgentApprovalResolvedEvent),
@@ -188,6 +198,7 @@ impl Serialize for EventKind {
                 "agent_handoff_validation_failed",
                 serde_json::to_value(value),
             ),
+            Self::AgentAttachment(value) => ("agent_attachment", serde_json::to_value(value)),
             Self::AgentFollowup(value) => ("agent_followup", serde_json::to_value(value)),
             Self::AgentApprovalRequested(value) => {
                 ("agent_approval_requested", serde_json::to_value(value))
@@ -248,6 +259,7 @@ impl<'de> Deserialize<'de> for EventKind {
             "agent_handoff_validation_failed" => {
                 decode(raw.data).map(Self::AgentHandoffValidationFailed)
             }
+            "agent_attachment" => decode(raw.data).map(Self::AgentAttachment),
             "agent_followup" => decode(raw.data).map(Self::AgentFollowup),
             "agent_approval_requested" => decode(raw.data).map(Self::AgentApprovalRequested),
             "agent_approval_resolved" => decode(raw.data).map(Self::AgentApprovalResolved),
@@ -1019,6 +1031,7 @@ mod tests {
                     verification: vec![],
                     blockers: vec![],
                     followups: vec![],
+                    attachments: vec![],
                     confidence: HandoffConfidence::High,
                 },
                 Some(HandoffStatus::Completed),

--- a/ovim-core/src/run_log/query.rs
+++ b/ovim-core/src/run_log/query.rs
@@ -308,6 +308,7 @@ fn event_kind_label(kind: &EventKind) -> String {
         EventKind::AgentProgress(_) => "agent.progress".into(),
         EventKind::AgentHandoff(_) => "agent.handoff".into(),
         EventKind::AgentHandoffValidationFailed(_) => "agent.handoff_validation_failed".into(),
+        EventKind::AgentAttachment(_) => "agent.attachment".into(),
         EventKind::AgentFollowup(_) => "agent.followup".into(),
         EventKind::AgentApprovalRequested(_) => "agent.approval.requested".into(),
         EventKind::AgentApprovalResolved(_) => "agent.approval.resolved".into(),

--- a/ovim-core/src/run_log/sqlite.rs
+++ b/ovim-core/src/run_log/sqlite.rs
@@ -585,6 +585,7 @@ fn event_kind_name(kind: &super::EventKind) -> &str {
         super::EventKind::AgentProgress(_) => "agent_progress",
         super::EventKind::AgentHandoff(_) => "agent_handoff",
         super::EventKind::AgentHandoffValidationFailed(_) => "agent_handoff_validation_failed",
+        super::EventKind::AgentAttachment(_) => "agent_attachment",
         super::EventKind::AgentFollowup(_) => "agent_followup",
         super::EventKind::AgentApprovalRequested(_) => "agent_approval_requested",
         super::EventKind::AgentApprovalResolved(_) => "agent_approval_resolved",

--- a/user-docs/ai.md
+++ b/user-docs/ai.md
@@ -230,7 +230,9 @@ the parent reads selected content with `read_handoff_attachment`. Attachment
 blobs are content-addressed, retained with the run, and survive restart. An
 invalid or oversized handoff is preserved and returned to the retained child
 session for one repair attempt instead of being discarded at the provider
-boundary.
+boundary. Each child may create at most 16 attachments, each at most 1 MiB and
+at most 8 MiB in total. Terminalization verifies that every referenced artifact
+was durably created by that child.
 
 `send_message` queues a bounded parent-authored steer only to a live child.
 It does not start a new turn. Ovim records the message before notifying the

--- a/user-docs/ai.md
+++ b/user-docs/ai.md
@@ -222,6 +222,16 @@ interrupts the named child hierarchy while preserving partial run history.
 While a delegated parent waits, it yields its provider-concurrency slot so a
 queued descendant can run; the parent reacquires capacity before resuming.
 
+Substantial child results belong in durable handoff attachments rather than an
+oversized terminal summary. A child calls `create_handoff_attachment` with a
+name, media type, and UTF-8 content, then includes the returned artifact ID in
+`submit_handoff.attachments`. The concise handoff reaches the parent normally;
+the parent reads selected content with `read_handoff_attachment`. Attachment
+blobs are content-addressed, retained with the run, and survive restart. An
+invalid or oversized handoff is preserved and returned to the retained child
+session for one repair attempt instead of being discarded at the provider
+boundary.
+
 `send_message` queues a bounded parent-authored steer only to a live child.
 It does not start a new turn. Ovim records the message before notifying the
 child, claims delivery by durable event ID, and presents it to the provider


### PR DESCRIPTION
## What changed

- add durable, content-addressed handoff attachments for delegated agents
- expose `create_handoff_attachment` to children and `read_handoff_attachment` to authorized parents
- carry attachment IDs through validated handoffs, mailbox projections, and headless snapshots
- preserve invalid or oversized handoffs at the runner boundary and give retained sessions one repair attempt
- validate that referenced artifacts were durably created by the submitting child
- centralize and enforce attachment size, count, cumulative-byte, and media-type policy
- document the attachment workflow and limits

## Why

Delegated agents could complete substantial work and then lose the entire result when a structured handoff summary exceeded the 4 KiB limit. The provider adapter rejected that payload before the runtime could preserve it or request a repair.

Large results now live in durable run artifacts while terminal handoffs remain concise. If a provider submits an invalid handoff—or invents or borrows an attachment ID—the runtime preserves it and asks the retained child to repair and resubmit.

## Impact

Each child can create up to 16 attachments, each at most 1 MiB and at most 8 MiB cumulatively. Attachment creation has an isolated provider transport ceiling; ordinary tools remain capped at 64 KiB. Attachment reads are restricted to the owner, its direct parent, or the durable root.

## Validation

- `cargo test -p ovim-core` — 1,521 passed
- doctests — 7 passed, 2 ignored
- `cargo check --workspace`
- `cargo clippy -p ovim-core --tests -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
