### PR TITLE
Trust temp files created by the active AI session

### DIFF
--- a/ovim-core/src/ai/auto_mode.rs
+++ b/ovim-core/src/ai/auto_mode.rs
@@ -618,7 +618,7 @@ fn double_quoted_substitutions(command: &str) -> Vec<&str> {
     substitutions
 }
 
-fn shell_tokens(command: &str) -> Vec<String> {
+pub(crate) fn shell_tokens(command: &str) -> Vec<String> {
     let chars: Vec<char> = command.chars().collect();
     let mut tokens = Vec::new();
     let mut word = String::new();

--- a/ovim-core/src/buffer/encoding.rs
+++ b/ovim-core/src/buffer/encoding.rs
@@ -80,15 +80,19 @@ impl FileEncoding {
                 .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {}", e)),
             FileEncoding::Utf16Le => {
                 let u16_vec: Vec<u16> = bytes
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|chunk| u16::from_le_bytes(*chunk))
                     .collect();
                 String::from_utf16(&u16_vec).map_err(|e| anyhow::anyhow!("Invalid UTF-16LE: {}", e))
             }
             FileEncoding::Utf16Be => {
                 let u16_vec: Vec<u16> = bytes
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|chunk| u16::from_be_bytes(*chunk))
                     .collect();
                 String::from_utf16(&u16_vec).map_err(|e| anyhow::anyhow!("Invalid UTF-16BE: {}", e))
             }

--- a/ovim-core/src/editor/ai_chat_mutations.rs
+++ b/ovim-core/src/editor/ai_chat_mutations.rs
@@ -727,6 +727,10 @@ impl Editor {
 
     fn handle_write_file_at_path(&mut self, args: WriteFileArgs, create_only: bool) -> ToolResult {
         let path = args.path;
+        let created_new_file = self
+            .buffer()
+            .file_path()
+            .is_some_and(|target| !std::path::Path::new(target).exists());
         let mut content = args.content;
         if !content.is_empty() && !content.ends_with('\n') {
             content.push('\n');
@@ -769,6 +773,11 @@ impl Editor {
             Ok(s) => s,
             Err(e) => return e,
         };
+        if created_new_file {
+            if let Some(target) = self.buffer().file_path().map(std::path::PathBuf::from) {
+                self.record_current_session_temp_file(&target);
+            }
+        }
 
         // Mark full file as edited for review mode.
         let buffer_id = self.buffer().id();

--- a/ovim-core/src/editor/ai_chat_state.rs
+++ b/ovim-core/src/editor/ai_chat_state.rs
@@ -283,6 +283,8 @@ pub fn kill_shell_process_group(pid: u32) {
 pub struct ShellExecutionObservation {
     pub result: crate::ai::tools::ToolResult,
     pub delta: Option<crate::run_log::WorkspaceDelta>,
+    /// Exact, previously absent temp files named by this shell command.
+    pub created_temp_files: Vec<PathBuf>,
     pub capture_error: Option<String>,
     /// The command may have run, but its resulting disk state was not captured.
     pub outcome_unknown: bool,
@@ -756,6 +758,9 @@ pub struct AiChatState {
     /// Session-scoped roots explicitly approved for path-restricted tool access
     /// (outside-project and sensitive-path overrides).
     pub approved_external_roots: Vec<PathBuf>,
+    /// Exact temp files created during this live chat, shared by every turn
+    /// and agent participating in the session.
+    pub(super) created_temp_files: super::ai_session_temp::SessionTempFiles,
     /// Compact tool event summaries keyed by tool call id.
     pub tool_event_summaries: HashMap<String, ToolEventSummary>,
     /// Images loaded by a tool and waiting to be attached to its tool result.
@@ -945,6 +950,7 @@ impl AiChatState {
             code_explanation_cache_bytes: 0,
             pending_no_repo_folder_approval: None,
             approved_external_roots: Vec::new(),
+            created_temp_files: Default::default(),
             tool_event_summaries: HashMap::new(),
             tool_result_images: HashMap::new(),
             file_snapshots: HashMap::new(),

--- a/ovim-core/src/editor/ai_chat_tools.rs
+++ b/ovim-core/src/editor/ai_chat_tools.rs
@@ -424,6 +424,21 @@ impl Editor {
             return None;
         }
         let mode = self.active_chat_tool_approval_mode();
+        if mode != ToolApprovalMode::AlwaysPrompt
+            && (requested_path
+                .as_deref()
+                .is_some_and(|path| self.current_session_created_temp_file(path))
+                || (tc.name == "bash"
+                    && tc
+                        .arguments
+                        .get("command")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|command| {
+                            self.current_session_authorizes_temp_shell_command(command)
+                        })))
+        {
+            return None;
+        }
         if mode == ToolApprovalMode::Auto {
             return None;
         }

--- a/ovim-core/src/editor/ai_chat_tools_tests.rs
+++ b/ovim-core/src/editor/ai_chat_tools_tests.rs
@@ -491,6 +491,121 @@ fn write_file_at_path_creates_missing_file() {
 }
 
 #[test]
+fn session_created_temp_file_can_be_rewritten_and_executed_without_more_approval() {
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    runtime.block_on(async {
+        let repository = tempfile::tempdir().expect("repository");
+        git2::Repository::init(repository.path()).expect("init repository");
+        let source = repository.path().join("main.rs");
+        fs::write(&source, "fn main() {}\n").expect("seed source");
+        let temp = tempfile::tempdir_in(std::env::temp_dir()).expect("session temp parent");
+        let script = temp.path().join("agent-script.sh");
+        let runs = tempfile::tempdir().expect("run storage");
+
+        let mut editor = Editor::default();
+        *editor.ai_state = super::super::ai_state::AiState::with_run_storage_layout(
+            crate::run_log::RunStorageLayout::new(runs.path()),
+        )
+        .expect("isolated run storage");
+        editor.open_file(&source).expect("open source");
+        editor
+            .open_ai_chat(ChatOpts {
+                name: "chat".to_string(),
+                allow_edits: true,
+                ..Default::default()
+            })
+            .expect("open chat");
+        set_active_profile_project_scope(&mut editor);
+        editor.ai_state.config.tool_approval_mode = ToolApprovalMode::SensitivePrompt;
+
+        let create = ToolCallInfo {
+            id: "create-temp-script".into(),
+            name: "create_file".into(),
+            arguments: serde_json::json!({
+                "path": script.to_string_lossy(),
+                "content": "#!/bin/sh\nprintf first",
+                "expected_revision": 0,
+            }),
+        };
+        match editor.dispatch_tool_call_with_approval(
+            &create,
+            Some(&temp.path().canonicalize().expect("canonical temp parent")),
+        ) {
+            ToolDispatchOutcome::Completed(ToolResult::Success(_)) => {}
+            ToolDispatchOutcome::Completed(ToolResult::Error(error)) => {
+                panic!("create failed: {error}")
+            }
+            ToolDispatchOutcome::ApprovalRequired(request) => {
+                panic!("initial one-shot approval was ignored: {}", request.message)
+            }
+        }
+        assert!(editor.current_session_created_temp_file(&script));
+
+        let rewrite = ToolCallInfo {
+            id: "rewrite-temp-script".into(),
+            name: "write_file_at_path".into(),
+            arguments: serde_json::json!({
+                "path": script.to_string_lossy(),
+                "content": "#!/bin/sh\nprintf second",
+                "expected_revision": editor.build_tool_execution_context().buffer_revision,
+            }),
+        };
+        match editor.dispatch_tool_call_with_approval(&rewrite, None) {
+            ToolDispatchOutcome::Completed(ToolResult::Success(_)) => {}
+            ToolDispatchOutcome::Completed(ToolResult::Error(error)) => {
+                panic!("rewrite failed: {error}")
+            }
+            ToolDispatchOutcome::ApprovalRequired(request) => {
+                panic!("owned temp rewrite requested approval: {}", request.message)
+            }
+        }
+
+        for (id, command) in [
+            (
+                "chmod-temp-script",
+                format!("chmod +x {}", script.display()),
+            ),
+            ("run-temp-script", script.display().to_string()),
+        ] {
+            let call = ToolCallInfo {
+                id: id.into(),
+                name: "bash".into(),
+                arguments: serde_json::json!({"command": command}),
+            };
+            match editor.dispatch_tool_call_with_approval(&call, None) {
+                ToolDispatchOutcome::Completed(ToolResult::Success(output)) => {
+                    if id == "run-temp-script" {
+                        assert!(output.contains("second"), "{output}");
+                    }
+                }
+                ToolDispatchOutcome::Completed(ToolResult::Error(error)) => {
+                    panic!("{id} failed: {error}")
+                }
+                ToolDispatchOutcome::ApprovalRequired(request) => {
+                    panic!("{id} requested approval: {}", request.message)
+                }
+            }
+        }
+
+        let unowned = temp.path().join("unowned.sh");
+        fs::write(&unowned, "#!/bin/sh\n").expect("seed unowned sibling");
+        let call = ToolCallInfo {
+            id: "rewrite-unowned-temp".into(),
+            name: "write_file_at_path".into(),
+            arguments: serde_json::json!({
+                "path": unowned.to_string_lossy(),
+                "content": "must require approval",
+                "expected_revision": 0,
+            }),
+        };
+        assert!(matches!(
+            editor.dispatch_tool_call_with_approval(&call, None),
+            ToolDispatchOutcome::ApprovalRequired(_)
+        ));
+    });
+}
+
+#[test]
 fn missing_expected_revision_does_not_prepare_path_target() {
     let dir = tempfile::tempdir().expect("tempdir");
     let target = dir.path().join("not_opened.rs");

--- a/ovim-core/src/editor/ai_chat_tools_tests.rs
+++ b/ovim-core/src/editor/ai_chat_tools_tests.rs
@@ -499,6 +499,7 @@ fn session_created_temp_file_can_be_rewritten_and_executed_without_more_approval
         let source = repository.path().join("main.rs");
         fs::write(&source, "fn main() {}\n").expect("seed source");
         let temp = tempfile::tempdir_in(std::env::temp_dir()).expect("session temp parent");
+        git2::Repository::init(temp.path()).expect("init unrelated temp repository");
         let script = temp.path().join("agent-script.sh");
         let runs = tempfile::tempdir().expect("run storage");
 
@@ -540,6 +541,17 @@ fn session_created_temp_file_can_be_rewritten_and_executed_without_more_approval
             }
         }
         assert!(editor.current_session_created_temp_file(&script));
+        assert_eq!(
+            editor
+                .ai_repo_root()
+                .expect("origin repository remains in scope")
+                .canonicalize()
+                .expect("canonical detected repository"),
+            repository
+                .path()
+                .canonicalize()
+                .expect("canonical repository")
+        );
 
         let rewrite = ToolCallInfo {
             id: "rewrite-temp-script".into(),

--- a/ovim-core/src/editor/ai_chat_turn.rs
+++ b/ovim-core/src/editor/ai_chat_turn.rs
@@ -743,6 +743,10 @@ impl Editor {
             );
             return;
         };
+        if self.current_session_authorizes_temp_shell_command(&command) {
+            self.execute_dynamic_tool_after_policy(turn, tool, call, response, None, false);
+            return;
+        }
         let request = ClassifierRequest::new(
             ShellProposal {
                 command,
@@ -1004,6 +1008,8 @@ impl Editor {
         let task_command = command.clone();
         let task_workdir = workdir.clone();
         let task = tokio::task::spawn_blocking(move || {
+            let temp_probe =
+                super::ai_session_temp::TempPathProbe::for_shell_command(&task_command);
             let observation = match crate::run_log::capture_workspace(&task_workdir, &artifact_store) {
                 Ok(before) => {
                     let result = super::ai_tool_execution::run_bash_program(
@@ -1018,12 +1024,14 @@ impl Editor {
                         Ok(after) => super::ai_chat_state::ShellExecutionObservation {
                             result,
                             delta: Some(before.diff(after)),
+                            created_temp_files: temp_probe.created_files(),
                             capture_error: None,
                             outcome_unknown: false,
                         },
                         Err(error) => super::ai_chat_state::ShellExecutionObservation {
                             result,
                             delta: None,
+                            created_temp_files: Vec::new(),
                             capture_error: Some(format!(
                                 "shell completed, but after-state capture failed: {error}"
                             )),
@@ -1036,6 +1044,7 @@ impl Editor {
                         "shell program was not executed because before-state capture failed: {error}"
                     )),
                     delta: None,
+                    created_temp_files: Vec::new(),
                     capture_error: Some(error),
                     outcome_unknown: false,
                 },
@@ -1104,6 +1113,7 @@ impl Editor {
                             "shell execution task stopped without a result".into(),
                         ),
                         delta: None,
+                        created_temp_files: Vec::new(),
                         capture_error: Some(
                             "shell execution and workspace result are unknown".into(),
                         ),
@@ -1119,6 +1129,9 @@ impl Editor {
             .and_then(|chat| chat.pending_shell_execution.take())
             .expect("pending shell exists");
         let observation = received.expect("shell result");
+        for path in &observation.created_temp_files {
+            self.record_current_session_temp_file(path);
+        }
         if let Some(chat) = self.ai_state.chat.as_mut() {
             let phase = if observation.outcome_unknown {
                 super::ai_chat_state::ShellTranscriptPhase::OutcomeUnknown

--- a/ovim-core/src/editor/ai_session_temp.rs
+++ b/ovim-core/src/editor/ai_session_temp.rs
@@ -29,6 +29,9 @@ impl TempFileIdentity {
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
+            if metadata.nlink() != 1 {
+                return None;
+            }
             Some(Self {
                 device: metadata.dev(),
                 inode: metadata.ino(),
@@ -87,6 +90,12 @@ impl SessionTempFiles {
             return words[1..]
                 .iter()
                 .all(|word| self.argument_stays_in_scope(word, project_root));
+        }
+
+        // Interpreter and utility exemptions only apply to normal PATH lookups. An
+        // arbitrary executable named `bash` or `chmod` must not inherit authority.
+        if program_path.is_absolute() || program.contains(['/', '\\']) {
+            return false;
         }
 
         let program_name = program_path
@@ -266,6 +275,22 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn hard_linking_a_recorded_file_revokes_authority() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        let alias = directory.path().join("alias.sh");
+        fs::write(&file, "#!/bin/sh\n").unwrap();
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+
+        fs::hard_link(&file, &alias).unwrap();
+        assert!(!files.contains(&file));
+        assert!(!files.contains(&alias));
+        assert!(!files.record(&alias));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn canonical_temp_aliases_share_the_same_authority() {
         let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
         let file = directory.path().join("owned.sh");
@@ -328,5 +353,12 @@ mod tests {
         ));
         assert!(!files
             .authorizes_shell_command(&format!("{} ../outside", script.display()), project.path()));
+
+        let fake_bash = directory.path().join("bash");
+        fs::write(&fake_bash, "#!/bin/sh\n").unwrap();
+        assert!(!files.authorizes_shell_command(
+            &format!("{} {}", fake_bash.display(), script.display()),
+            project.path()
+        ));
     }
 }

--- a/ovim-core/src/editor/ai_session_temp.rs
+++ b/ovim-core/src/editor/ai_session_temp.rs
@@ -1,0 +1,332 @@
+use crate::ai::path_policy::canonicalize_or_normalize;
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+/// Exact temporary files created by the active chat session.
+///
+/// This is intentionally an exact-file registry, not an allowlist for the
+/// system temp directory. File identity is revalidated on Unix so replacing a
+/// recorded path does not inherit the session's authority.
+#[derive(Debug, Default)]
+pub(super) struct SessionTempFiles {
+    files: HashMap<PathBuf, TempFileIdentity>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TempFileIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl TempFileIdentity {
+    fn read(path: &Path) -> Option<Self> {
+        let metadata = std::fs::metadata(path).ok()?;
+        if !metadata.is_file() {
+            return None;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Some(Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Some(Self {})
+        }
+    }
+}
+
+impl SessionTempFiles {
+    pub(super) fn record(&mut self, path: &Path) -> bool {
+        let Some(path) = canonical_temp_file(path) else {
+            return false;
+        };
+        let Some(identity) = TempFileIdentity::read(&path) else {
+            return false;
+        };
+        self.files.insert(path, identity);
+        true
+    }
+
+    pub(super) fn contains(&self, path: &Path) -> bool {
+        let Some(path) = canonical_temp_file(path) else {
+            return false;
+        };
+        let Some(expected) = self.files.get(&path) else {
+            return false;
+        };
+        TempFileIdentity::read(&path).as_ref() == Some(expected)
+    }
+
+    /// Return true for the narrow shell forms needed to make or run a
+    /// session-created temp file. General shell programs still use normal auto
+    /// mode because an owned file argument must not authorize unrelated
+    /// external effects in the same command.
+    pub(super) fn authorizes_shell_command(&self, command: &str, project_root: &Path) -> bool {
+        if command.chars().any(|character| {
+            matches!(
+                character,
+                '|' | '&' | ';' | '>' | '<' | '\n' | '`' | '$' | '(' | ')'
+            )
+        }) {
+            return false;
+        }
+        let Some(words) = shlex::split(command) else {
+            return false;
+        };
+        let Some(program) = words.first() else {
+            return false;
+        };
+        let program_path = Path::new(program);
+        if program_path.is_absolute() && self.contains(program_path) {
+            return words[1..]
+                .iter()
+                .all(|word| self.argument_stays_in_scope(word, project_root));
+        }
+
+        let program_name = program_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(program);
+        match program_name {
+            "chmod" => {
+                let Some((mode, targets)) = words[1..].split_first() else {
+                    return false;
+                };
+                is_simple_chmod_mode(mode)
+                    && !targets.is_empty()
+                    && targets
+                        .iter()
+                        .all(|target| self.contains(Path::new(target)))
+            }
+            "sh" | "bash" | "zsh" | "python" | "python3" | "node" | "ruby" | "perl" => {
+                let Some(script) = words[1..].iter().find(|word| !word.starts_with('-')) else {
+                    return false;
+                };
+                self.contains(Path::new(script))
+                    && words
+                        .iter()
+                        .skip_while(|word| *word != script)
+                        .skip(1)
+                        .all(|word| self.argument_stays_in_scope(word, project_root))
+            }
+            _ => false,
+        }
+    }
+
+    fn argument_stays_in_scope(&self, word: &str, project_root: &Path) -> bool {
+        let candidate = word.split_once('=').map_or(word, |(_, value)| value);
+        let path = Path::new(candidate);
+        if path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+        {
+            return false;
+        }
+        if !path.is_absolute() {
+            return true;
+        }
+        let path = canonicalize_or_normalize(path);
+        path.starts_with(canonicalize_or_normalize(project_root)) || self.contains(&path)
+    }
+}
+
+fn is_simple_chmod_mode(mode: &str) -> bool {
+    (!mode.is_empty() && mode.chars().all(|character| character.is_ascii_digit()))
+        || (mode.contains(['+', '-', '='])
+            && mode.chars().all(|character| {
+                matches!(
+                    character,
+                    'u' | 'g' | 'o' | 'a' | '+' | '-' | '=' | 'r' | 'w' | 'x' | 'X' | 's' | 't'
+                )
+            }))
+}
+
+/// Snapshot the literal temp paths named by a shell command. Only paths that
+/// did not exist before the command and are regular files afterwards are
+/// returned. This avoids scanning shared temp directories or attributing
+/// another process's unrelated files to the agent session.
+pub(super) struct TempPathProbe {
+    missing_candidates: Vec<PathBuf>,
+}
+
+impl TempPathProbe {
+    pub(super) fn for_shell_command(command: &str) -> Self {
+        let missing_candidates = shell_temp_path_candidates(command)
+            .into_iter()
+            .filter(|path| !path.exists())
+            .collect();
+        Self { missing_candidates }
+    }
+
+    pub(super) fn created_files(self) -> Vec<PathBuf> {
+        self.missing_candidates
+            .into_iter()
+            .filter_map(|path| canonical_temp_file(&path))
+            .collect()
+    }
+}
+
+fn shell_temp_path_candidates(command: &str) -> Vec<PathBuf> {
+    let mut candidates = BTreeSet::new();
+    for token in crate::ai::auto_mode::shell_tokens(command) {
+        let mut values = vec![token.as_str()];
+        if let Some((_, value)) = token.split_once('=') {
+            values.push(value);
+        }
+        for value in values {
+            let value = value.trim_matches(|character: char| {
+                matches!(character, ',' | ':' | '[' | ']' | '{' | '}')
+            });
+            let expanded = expand_temp_variable(value);
+            let path = Path::new(&expanded);
+            if path.is_absolute() && is_temp_location(path) {
+                candidates.insert(canonicalize_or_normalize(path));
+            }
+        }
+    }
+    candidates.into_iter().collect()
+}
+
+fn expand_temp_variable(value: &str) -> String {
+    for prefix in ["$TMPDIR", "${TMPDIR}", "$TEMP", "${TEMP}", "$TMP", "${TMP}"] {
+        if let Some(suffix) = value.strip_prefix(prefix) {
+            return std::env::temp_dir()
+                .join(suffix.trim_start_matches(['/', '\\']))
+                .to_string_lossy()
+                .into_owned();
+        }
+    }
+    value.to_string()
+}
+
+fn canonical_temp_file(path: &Path) -> Option<PathBuf> {
+    let path = path.canonicalize().ok()?;
+    (path.is_file() && is_temp_location(&path)).then_some(path)
+}
+
+pub(super) fn is_temp_location(path: &Path) -> bool {
+    let path = canonicalize_or_normalize(path);
+    temp_roots()
+        .into_iter()
+        .any(|root| path != root && path.starts_with(root))
+}
+
+fn temp_roots() -> Vec<PathBuf> {
+    let mut roots = BTreeSet::new();
+    roots.insert(canonicalize_or_normalize(&std::env::temp_dir()));
+    #[cfg(unix)]
+    for conventional in ["/tmp", "/var/tmp", "/private/tmp"] {
+        let path = Path::new(conventional);
+        if path.is_dir() {
+            roots.insert(canonicalize_or_normalize(path));
+        }
+    }
+    roots.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn records_only_exact_regular_temp_files() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        fs::write(&file, "#!/bin/sh\n").unwrap();
+        let sibling = directory.path().join("not-owned.sh");
+        fs::write(&sibling, "#!/bin/sh\n").unwrap();
+
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+        assert!(files.contains(&file));
+        assert!(!files.contains(&sibling));
+        assert!(!files.contains(directory.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacing_a_recorded_inode_revokes_authority() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        fs::write(&file, "old\n").unwrap();
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+
+        fs::remove_file(&file).unwrap();
+        fs::write(&file, "replacement\n").unwrap();
+        assert!(!files.contains(&file));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_temp_aliases_share_the_same_authority() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        fs::write(&file, "#!/bin/sh\n").unwrap();
+        let alias = directory.path().with_extension("alias");
+        std::os::unix::fs::symlink(directory.path(), &alias).unwrap();
+        let alias_file = alias.join("owned.sh");
+
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+        assert!(files.contains(&alias_file));
+        fs::remove_file(alias).unwrap();
+    }
+
+    #[test]
+    fn probe_attributes_only_new_literal_temp_files() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let existing = directory.path().join("existing");
+        let created = directory.path().join("created");
+        fs::write(&existing, "before\n").unwrap();
+        let command = format!(
+            "printf after > {} && printf new > {}",
+            existing.display(),
+            created.display()
+        );
+        let probe = TempPathProbe::for_shell_command(&command);
+        fs::write(&existing, "after\n").unwrap();
+        fs::write(&created, "new\n").unwrap();
+
+        assert_eq!(probe.created_files(), vec![created.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn authorizes_only_narrow_owned_file_shell_forms() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let script = directory.path().join("owned.sh");
+        fs::write(&script, "#!/bin/sh\n").unwrap();
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&script));
+        let project = tempfile::tempdir().unwrap();
+
+        assert!(files
+            .authorizes_shell_command(&format!("chmod +x {}", script.display()), project.path()));
+        assert!(files.authorizes_shell_command(&script.display().to_string(), project.path()));
+        assert!(files.authorizes_shell_command(
+            &format!("bash {} --check", script.display()),
+            project.path()
+        ));
+        assert!(!files.authorizes_shell_command(
+            &format!("{}; curl https://example.test", script.display()),
+            project.path()
+        ));
+        assert!(!files.authorizes_shell_command(
+            &format!("chmod +x {}/unowned", directory.path().display()),
+            project.path()
+        ));
+        assert!(!files.authorizes_shell_command(
+            &format!("chmod --reference=/etc/passwd {}", script.display()),
+            project.path()
+        ));
+        assert!(!files
+            .authorizes_shell_command(&format!("{} ../outside", script.display()), project.path()));
+    }
+}

--- a/ovim-core/src/editor/ai_tool_path.rs
+++ b/ovim-core/src/editor/ai_tool_path.rs
@@ -61,6 +61,17 @@ impl Editor {
             .is_some_and(|root| requested_path.starts_with(root));
         let approved_session_match = self.current_session_approved_root_for(&requested_path);
 
+        // A session owns only the exact temp files it created. This check is
+        // deliberately before the project boundary prompt but after
+        // canonicalization, so platform aliases such as /tmp and /private/tmp
+        // resolve to the same file without granting the surrounding folder.
+        if self.current_session_created_temp_file(&requested_path) {
+            return Ok(ToolPathResolution::Allowed {
+                absolute_path: requested_path.clone(),
+                boundary_root: requested_path,
+            });
+        }
+
         if requested_path.starts_with(&boundary_root) {
             if let Some(reason) = sensitive_path_reason(&requested_path) {
                 let approved_sensitive = self.ai_chat_yolo_mode()
@@ -160,6 +171,30 @@ impl Editor {
         None
     }
 
+    pub(super) fn current_session_created_temp_file(&self, path: &Path) -> bool {
+        self.ai_state
+            .chat
+            .as_ref()
+            .is_some_and(|chat| chat.created_temp_files.contains(path))
+    }
+
+    pub(super) fn record_current_session_temp_file(&mut self, path: &Path) -> bool {
+        self.ai_state
+            .chat
+            .as_mut()
+            .is_some_and(|chat| chat.created_temp_files.record(path))
+    }
+
+    pub(super) fn current_session_authorizes_temp_shell_command(&self, command: &str) -> bool {
+        let Some(project_root) = self.ai_effective_project_root() else {
+            return false;
+        };
+        self.ai_state.chat.as_ref().is_some_and(|chat| {
+            chat.created_temp_files
+                .authorizes_shell_command(command, &project_root)
+        })
+    }
+
     /// Effective project boundary for AI project-level tools.
     ///
     /// Prefers git repository root. Outside git, falls back to a
@@ -190,7 +225,20 @@ impl Editor {
             .map(PathBuf::from);
         let current_file = self.buffer().file_path().map(PathBuf::from);
 
-        if let Some(file) = active_target_file.or(origin_file).or(current_file) {
+        // Opening a temp artifact as the mutation target must not replace the
+        // chat's repository boundary. Keep resolving policy and capabilities
+        // from the originating project while that exact artifact is active.
+        let active_target_is_unscoped_temp = active_target_file.as_deref().is_some_and(|path| {
+            super::ai_session_temp::is_temp_location(path)
+                && discover_repo_root_from_start(path).is_none()
+        });
+        let target_file = if active_target_is_unscoped_temp {
+            origin_file.or(active_target_file)
+        } else {
+            active_target_file.or(origin_file)
+        };
+
+        if let Some(file) = target_file.or(current_file) {
             Some(self.absolutize_path(&file))
         } else {
             std::env::current_dir().ok()

--- a/ovim-core/src/editor/ai_tool_path.rs
+++ b/ovim-core/src/editor/ai_tool_path.rs
@@ -228,11 +228,10 @@ impl Editor {
         // Opening a temp artifact as the mutation target must not replace the
         // chat's repository boundary. Keep resolving policy and capabilities
         // from the originating project while that exact artifact is active.
-        let active_target_is_unscoped_temp = active_target_file.as_deref().is_some_and(|path| {
-            super::ai_session_temp::is_temp_location(path)
-                && discover_repo_root_from_start(path).is_none()
-        });
-        let target_file = if active_target_is_unscoped_temp {
+        let active_target_is_session_temp = active_target_file
+            .as_deref()
+            .is_some_and(|path| self.current_session_created_temp_file(path));
+        let target_file = if active_target_is_session_temp {
             origin_file.or(active_target_file)
         } else {
             active_target_file.or(origin_file)

--- a/ovim-core/src/editor/mod.rs
+++ b/ovim-core/src/editor/mod.rs
@@ -23,6 +23,7 @@ mod ai_comprehension;
 mod ai_durable_chat;
 pub(crate) mod ai_integration;
 mod ai_run_events;
+mod ai_session_temp;
 mod ai_shell_process;
 mod ai_skills;
 mod ai_state;

--- a/ovim-core/src/lua/editor_bridge.rs
+++ b/ovim-core/src/lua/editor_bridge.rs
@@ -312,7 +312,7 @@ impl EditorBridge {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        inner.pending_commands.drain(..).collect()
+        std::mem::take(&mut inner.pending_commands)
     }
 
     /// Get a specific line from the buffer
@@ -388,7 +388,7 @@ impl EditorBridge {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        inner.ai_pending_commands.drain(..).collect()
+        std::mem::take(&mut inner.ai_pending_commands)
     }
 
     pub fn register_api_key(&self, name: String, config: ApiKeyConfig) {

--- a/ovim-core/src/run_log/artifact.rs
+++ b/ovim-core/src/run_log/artifact.rs
@@ -70,7 +70,7 @@ impl FromStr for BlobId {
         }
 
         let mut bytes = [0; 32];
-        for (index, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
+        for (index, pair) in hex.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             bytes[index] = (hex_digit(pair[0]).ok_or(InvalidBlobId::InvalidHex)? << 4)
                 | hex_digit(pair[1]).ok_or(InvalidBlobId::InvalidHex)?;
         }

--- a/user-docs/ai.md
+++ b/user-docs/ai.md
@@ -72,6 +72,15 @@ read-only inputs and do not trigger outside-project approval prompts. To opt
 out of auto mode, set `tool_approval_mode = "sensitive_prompt"` or
 `"always_prompt"` in legacy `ai.toml`.
 
+An exact temporary file created by the active chat keeps that session's
+authority for later reads, edits, `chmod +x`, and execution. Ovim uses the
+platform temp directory and canonical paths, so aliases such as macOS `/tmp`
+and `/private/tmp` identify the same file. The grant never expands to the
+surrounding temp folder or a sibling file, and replacing the recorded file on
+Unix revokes it. Shell attribution considers only previously absent temp paths
+named by that command; Ovim does not scan the shared temp directory.
+The explicit `always_prompt` policy still prompts for every effect.
+
 For trusted work where approval interruptions are more costly than the safety
 gate, click `YOLO OFF` at the top right of the chat to switch it to `YOLO ON`.
 YOLO is opt-in per chat and defaults off. It bypasses Terra and interactive tool


### PR DESCRIPTION
## Summary

- track exact regular files created in platform temp locations by the active chat session
- canonicalize temp roots and aliases, and revalidate Unix device/inode identity before reusing authority
- allow later reads, rewrites, narrow `chmod` operations, and execution without another approval while keeping sibling files and replacement inodes untrusted
- attribute literal temp paths created by shell calls without scanning shared temp directories
- preserve the originating repository boundary while an unscoped temp artifact is the active mutation target
- document the behavior and preserve explicit `always_prompt` semantics

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ovim-core ai_session_temp --lib`
- `cargo test -p ovim-core session_created_temp_file_can_be_rewritten_and_executed_without_more_approval --lib`
- `TMPDIR=/var/tmp/ovim-codex-validation-20260823 cargo test -p ovim-core --lib --quiet` (1574 passed)
- `TMPDIR=/var/tmp/ovim-codex-validation-20260823 cargo clippy --workspace --all-targets -- -D warnings`