### PR TITLE
feat(auth): support Codex device login over SSH

### DIFF
--- a/ovim-core/src/ai/auto_mode.rs
+++ b/ovim-core/src/ai/auto_mode.rs
@@ -618,7 +618,7 @@ fn double_quoted_substitutions(command: &str) -> Vec<&str> {
     substitutions
 }
 
-fn shell_tokens(command: &str) -> Vec<String> {
+pub(crate) fn shell_tokens(command: &str) -> Vec<String> {
     let chars: Vec<char> = command.chars().collect();
     let mut tokens = Vec::new();
     let mut word = String::new();

--- a/ovim-core/src/ai/codex_auth.rs
+++ b/ovim-core/src/ai/codex_auth.rs
@@ -21,11 +21,37 @@ const AUTH_SCHEMA_VERSION: u8 = 2;
 const AUTH_ORIGIN: &str = "ovim_pkce";
 const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const DEVICE_AUTH_BASE_URL: &str = "https://auth.openai.com/api/accounts/deviceauth";
+const DEVICE_VERIFICATION_URL: &str = "https://auth.openai.com/codex/device";
+const DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const CALLBACK_PORT: u16 = 1455;
 const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
 const REFRESH_MARGIN_SECONDS: u64 = 60;
 const LOGIN_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const DEVICE_LOGIN_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug)]
+pub(crate) struct DeviceLoginCode {
+    pub(crate) verification_url: String,
+    pub(crate) user_code: String,
+    device_auth_id: String,
+    interval: Duration,
+}
+
+#[derive(Deserialize)]
+struct DeviceUserCodeResponse {
+    device_auth_id: String,
+    #[serde(alias = "usercode")]
+    user_code: String,
+    interval: Value,
+}
+
+#[derive(Deserialize)]
+struct DeviceTokenResponse {
+    authorization_code: String,
+    code_verifier: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct StoredCredentials {
@@ -130,6 +156,107 @@ pub(crate) fn begin_login() -> Result<LoginAttempt> {
     })
 }
 
+/// Start OpenAI's device-code flow without opening a browser or listening on
+/// localhost. This is the first half of the SSH/headless login path: callers
+/// display the returned URL and one-time code before polling for approval.
+pub(crate) async fn request_device_login() -> Result<DeviceLoginCode> {
+    let client = Client::builder()
+        .build()
+        .context("failed to create Codex device login HTTP client")?;
+    request_device_login_from(&client, DEVICE_AUTH_BASE_URL).await
+}
+
+async fn request_device_login_from(client: &Client, base_url: &str) -> Result<DeviceLoginCode> {
+    let response = client
+        .post(format!("{}/usercode", base_url.trim_end_matches('/')))
+        .json(&serde_json::json!({ "client_id": CLIENT_ID }))
+        .send()
+        .await
+        .context("failed to request a Codex device login code")?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("failed to read the Codex device login response")?;
+    if !status.is_success() {
+        if status == reqwest::StatusCode::NOT_FOUND {
+            anyhow::bail!(
+                "device-code sign-in is not enabled for this account; press B to use browser sign-in"
+            );
+        }
+        anyhow::bail!("Codex device login returned {status}");
+    }
+    let response: DeviceUserCodeResponse =
+        serde_json::from_str(&body).context("Codex device login returned an invalid response")?;
+    let interval = parse_device_interval(&response.interval)?;
+    if response.device_auth_id.is_empty() || response.user_code.is_empty() {
+        anyhow::bail!("Codex device login returned an incomplete response");
+    }
+    Ok(DeviceLoginCode {
+        verification_url: DEVICE_VERIFICATION_URL.to_string(),
+        user_code: response.user_code,
+        device_auth_id: response.device_auth_id,
+        interval: Duration::from_secs(interval.max(1)),
+    })
+}
+
+/// Poll until the device code is approved, then exchange the resulting PKCE
+/// authorization code into Ovim's independent credential lineage.
+pub(crate) async fn complete_device_login(code: DeviceLoginCode) -> Result<()> {
+    let client = Client::builder()
+        .build()
+        .context("failed to create Codex device login HTTP client")?;
+    let token = poll_device_login(&client, DEVICE_AUTH_BASE_URL, &code).await?;
+    exchange_code_with_redirect(
+        &token.authorization_code,
+        &token.code_verifier,
+        DEVICE_REDIRECT_URI,
+    )
+    .await
+}
+
+async fn poll_device_login(
+    client: &Client,
+    base_url: &str,
+    code: &DeviceLoginCode,
+) -> Result<DeviceTokenResponse> {
+    let endpoint = format!("{}/token", base_url.trim_end_matches('/'));
+    let started = tokio::time::Instant::now();
+    loop {
+        let response = client
+            .post(&endpoint)
+            .json(&serde_json::json!({
+                "device_auth_id": code.device_auth_id,
+                "user_code": code.user_code,
+            }))
+            .send()
+            .await
+            .context("failed while waiting for Codex device login")?;
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .json()
+                .await
+                .context("Codex device login returned an invalid approval response");
+        }
+        if status != reqwest::StatusCode::FORBIDDEN && status != reqwest::StatusCode::NOT_FOUND {
+            anyhow::bail!("Codex device login failed with {status}");
+        }
+        let elapsed = started.elapsed();
+        if elapsed >= DEVICE_LOGIN_TIMEOUT {
+            anyhow::bail!("device sign-in timed out after 15 minutes; press Enter to try again");
+        }
+        tokio::time::sleep(code.interval.min(DEVICE_LOGIN_TIMEOUT - elapsed)).await;
+    }
+}
+
+fn parse_device_interval(value: &Value) -> Result<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|value| value.trim().parse().ok()))
+        .ok_or_else(|| anyhow!("Codex device login returned an invalid polling interval"))
+}
+
 fn build_authorize_url(verifier: &str, state: &str) -> Result<String> {
     let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .encode(Sha256::digest(verifier.as_bytes()));
@@ -227,6 +354,10 @@ fn parse_callback_request(request: &[u8], expected_state: &str) -> Result<String
 }
 
 async fn exchange_code(code: &str, verifier: &str) -> Result<()> {
+    exchange_code_with_redirect(code, verifier, REDIRECT_URI).await
+}
+
+async fn exchange_code_with_redirect(code: &str, verifier: &str, redirect_uri: &str) -> Result<()> {
     let client = Client::builder()
         .build()
         .context("failed to create Codex login HTTP client")?;
@@ -236,7 +367,7 @@ async fn exchange_code(code: &str, verifier: &str) -> Result<()> {
             ("grant_type", "authorization_code"),
             ("client_id", CLIENT_ID),
             ("code", code),
-            ("redirect_uri", REDIRECT_URI),
+            ("redirect_uri", redirect_uri),
             ("code_verifier", verifier),
         ])
         .send()
@@ -587,5 +718,25 @@ mod tests {
         let token = format!("header.{claims}.signature");
         assert_eq!(jwt_account_id(&token).as_deref(), Some("acct_123"));
         assert_eq!(jwt_expiry(&token), Some(1234));
+    }
+
+    #[test]
+    fn device_poll_interval_accepts_server_string_and_number_forms() {
+        assert_eq!(parse_device_interval(&serde_json::json!("5")).unwrap(), 5);
+        assert_eq!(parse_device_interval(&serde_json::json!(7)).unwrap(), 7);
+        assert!(parse_device_interval(&serde_json::json!("later")).is_err());
+    }
+
+    #[test]
+    fn device_response_accepts_both_user_code_spellings() {
+        for field in ["user_code", "usercode"] {
+            let value = serde_json::json!({
+                "device_auth_id": "device-1",
+                field: "ABCD-EFGH",
+                "interval": "5"
+            });
+            let response: DeviceUserCodeResponse = serde_json::from_value(value).unwrap();
+            assert_eq!(response.user_code, "ABCD-EFGH");
+        }
     }
 }

--- a/ovim-core/src/buffer/encoding.rs
+++ b/ovim-core/src/buffer/encoding.rs
@@ -80,15 +80,19 @@ impl FileEncoding {
                 .map_err(|e| anyhow::anyhow!("Invalid UTF-8: {}", e)),
             FileEncoding::Utf16Le => {
                 let u16_vec: Vec<u16> = bytes
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|chunk| u16::from_le_bytes(*chunk))
                     .collect();
                 String::from_utf16(&u16_vec).map_err(|e| anyhow::anyhow!("Invalid UTF-16LE: {}", e))
             }
             FileEncoding::Utf16Be => {
                 let u16_vec: Vec<u16> = bytes
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|chunk| u16::from_be_bytes(*chunk))
                     .collect();
                 String::from_utf16(&u16_vec).map_err(|e| anyhow::anyhow!("Invalid UTF-16BE: {}", e))
             }

--- a/ovim-core/src/editor/ai_chat_mutations.rs
+++ b/ovim-core/src/editor/ai_chat_mutations.rs
@@ -727,6 +727,10 @@ impl Editor {
 
     fn handle_write_file_at_path(&mut self, args: WriteFileArgs, create_only: bool) -> ToolResult {
         let path = args.path;
+        let created_new_file = self
+            .buffer()
+            .file_path()
+            .is_some_and(|target| !std::path::Path::new(target).exists());
         let mut content = args.content;
         if !content.is_empty() && !content.ends_with('\n') {
             content.push('\n');
@@ -769,6 +773,11 @@ impl Editor {
             Ok(s) => s,
             Err(e) => return e,
         };
+        if created_new_file {
+            if let Some(target) = self.buffer().file_path().map(std::path::PathBuf::from) {
+                self.record_current_session_temp_file(&target);
+            }
+        }
 
         // Mark full file as edited for review mode.
         let buffer_id = self.buffer().id();

--- a/ovim-core/src/editor/ai_chat_state.rs
+++ b/ovim-core/src/editor/ai_chat_state.rs
@@ -283,6 +283,8 @@ pub fn kill_shell_process_group(pid: u32) {
 pub struct ShellExecutionObservation {
     pub result: crate::ai::tools::ToolResult,
     pub delta: Option<crate::run_log::WorkspaceDelta>,
+    /// Exact, previously absent temp files named by this shell command.
+    pub created_temp_files: Vec<PathBuf>,
     pub capture_error: Option<String>,
     /// The command may have run, but its resulting disk state was not captured.
     pub outcome_unknown: bool,
@@ -756,6 +758,9 @@ pub struct AiChatState {
     /// Session-scoped roots explicitly approved for path-restricted tool access
     /// (outside-project and sensitive-path overrides).
     pub approved_external_roots: Vec<PathBuf>,
+    /// Exact temp files created during this live chat, shared by every turn
+    /// and agent participating in the session.
+    pub(super) created_temp_files: super::ai_session_temp::SessionTempFiles,
     /// Compact tool event summaries keyed by tool call id.
     pub tool_event_summaries: HashMap<String, ToolEventSummary>,
     /// Images loaded by a tool and waiting to be attached to its tool result.
@@ -945,6 +950,7 @@ impl AiChatState {
             code_explanation_cache_bytes: 0,
             pending_no_repo_folder_approval: None,
             approved_external_roots: Vec::new(),
+            created_temp_files: Default::default(),
             tool_event_summaries: HashMap::new(),
             tool_result_images: HashMap::new(),
             file_snapshots: HashMap::new(),

--- a/ovim-core/src/editor/ai_chat_tools.rs
+++ b/ovim-core/src/editor/ai_chat_tools.rs
@@ -424,6 +424,21 @@ impl Editor {
             return None;
         }
         let mode = self.active_chat_tool_approval_mode();
+        if mode != ToolApprovalMode::AlwaysPrompt
+            && (requested_path
+                .as_deref()
+                .is_some_and(|path| self.current_session_created_temp_file(path))
+                || (tc.name == "bash"
+                    && tc
+                        .arguments
+                        .get("command")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|command| {
+                            self.current_session_authorizes_temp_shell_command(command)
+                        })))
+        {
+            return None;
+        }
         if mode == ToolApprovalMode::Auto {
             return None;
         }

--- a/ovim-core/src/editor/ai_chat_tools_tests.rs
+++ b/ovim-core/src/editor/ai_chat_tools_tests.rs
@@ -491,6 +491,121 @@ fn write_file_at_path_creates_missing_file() {
 }
 
 #[test]
+fn session_created_temp_file_can_be_rewritten_and_executed_without_more_approval() {
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    runtime.block_on(async {
+        let repository = tempfile::tempdir().expect("repository");
+        git2::Repository::init(repository.path()).expect("init repository");
+        let source = repository.path().join("main.rs");
+        fs::write(&source, "fn main() {}\n").expect("seed source");
+        let temp = tempfile::tempdir_in(std::env::temp_dir()).expect("session temp parent");
+        let script = temp.path().join("agent-script.sh");
+        let runs = tempfile::tempdir().expect("run storage");
+
+        let mut editor = Editor::default();
+        *editor.ai_state = super::super::ai_state::AiState::with_run_storage_layout(
+            crate::run_log::RunStorageLayout::new(runs.path()),
+        )
+        .expect("isolated run storage");
+        editor.open_file(&source).expect("open source");
+        editor
+            .open_ai_chat(ChatOpts {
+                name: "chat".to_string(),
+                allow_edits: true,
+                ..Default::default()
+            })
+            .expect("open chat");
+        set_active_profile_project_scope(&mut editor);
+        editor.ai_state.config.tool_approval_mode = ToolApprovalMode::SensitivePrompt;
+
+        let create = ToolCallInfo {
+            id: "create-temp-script".into(),
+            name: "create_file".into(),
+            arguments: serde_json::json!({
+                "path": script.to_string_lossy(),
+                "content": "#!/bin/sh\nprintf first",
+                "expected_revision": 0,
+            }),
+        };
+        match editor.dispatch_tool_call_with_approval(
+            &create,
+            Some(&temp.path().canonicalize().expect("canonical temp parent")),
+        ) {
+            ToolDispatchOutcome::Completed(ToolResult::Success(_)) => {}
+            ToolDispatchOutcome::Completed(ToolResult::Error(error)) => {
+                panic!("create failed: {error}")
+            }
+            ToolDispatchOutcome::ApprovalRequired(request) => {
+                panic!("initial one-shot approval was ignored: {}", request.message)
+            }
+        }
+        assert!(editor.current_session_created_temp_file(&script));
+
+        let rewrite = ToolCallInfo {
+            id: "rewrite-temp-script".into(),
+            name: "write_file_at_path".into(),
+            arguments: serde_json::json!({
+                "path": script.to_string_lossy(),
+                "content": "#!/bin/sh\nprintf second",
+                "expected_revision": editor.build_tool_execution_context().buffer_revision,
+            }),
+        };
+        match editor.dispatch_tool_call_with_approval(&rewrite, None) {
+            ToolDispatchOutcome::Completed(ToolResult::Success(_)) => {}
+            ToolDispatchOutcome::Completed(ToolResult::Error(error)) => {
+                panic!("rewrite failed: {error}")
+            }
+            ToolDispatchOutcome::ApprovalRequired(request) => {
+                panic!("owned temp rewrite requested approval: {}", request.message)
+            }
+        }
+
+        for (id, command) in [
+            (
+                "chmod-temp-script",
+                format!("chmod +x {}", script.display()),
+            ),
+            ("run-temp-script", script.display().to_string()),
+        ] {
+            let call = ToolCallInfo {
+                id: id.into(),
+                name: "bash".into(),
+                arguments: serde_json::json!({"command": command}),
+            };
+            match editor.dispatch_tool_call_with_approval(&call, None) {
+                ToolDispatchOutcome::Completed(ToolResult::Success(output)) => {
+                    if id == "run-temp-script" {
+                        assert!(output.contains("second"), "{output}");
+                    }
+                }
+                ToolDispatchOutcome::Completed(ToolResult::Error(error)) => {
+                    panic!("{id} failed: {error}")
+                }
+                ToolDispatchOutcome::ApprovalRequired(request) => {
+                    panic!("{id} requested approval: {}", request.message)
+                }
+            }
+        }
+
+        let unowned = temp.path().join("unowned.sh");
+        fs::write(&unowned, "#!/bin/sh\n").expect("seed unowned sibling");
+        let call = ToolCallInfo {
+            id: "rewrite-unowned-temp".into(),
+            name: "write_file_at_path".into(),
+            arguments: serde_json::json!({
+                "path": unowned.to_string_lossy(),
+                "content": "must require approval",
+                "expected_revision": 0,
+            }),
+        };
+        assert!(matches!(
+            editor.dispatch_tool_call_with_approval(&call, None),
+            ToolDispatchOutcome::ApprovalRequired(_)
+        ));
+    });
+}
+
+#[test]
 fn missing_expected_revision_does_not_prepare_path_target() {
     let dir = tempfile::tempdir().expect("tempdir");
     let target = dir.path().join("not_opened.rs");

--- a/ovim-core/src/editor/ai_chat_tools_tests.rs
+++ b/ovim-core/src/editor/ai_chat_tools_tests.rs
@@ -499,6 +499,7 @@ fn session_created_temp_file_can_be_rewritten_and_executed_without_more_approval
         let source = repository.path().join("main.rs");
         fs::write(&source, "fn main() {}\n").expect("seed source");
         let temp = tempfile::tempdir_in(std::env::temp_dir()).expect("session temp parent");
+        git2::Repository::init(temp.path()).expect("init unrelated temp repository");
         let script = temp.path().join("agent-script.sh");
         let runs = tempfile::tempdir().expect("run storage");
 
@@ -540,6 +541,17 @@ fn session_created_temp_file_can_be_rewritten_and_executed_without_more_approval
             }
         }
         assert!(editor.current_session_created_temp_file(&script));
+        assert_eq!(
+            editor
+                .ai_repo_root()
+                .expect("origin repository remains in scope")
+                .canonicalize()
+                .expect("canonical detected repository"),
+            repository
+                .path()
+                .canonicalize()
+                .expect("canonical repository")
+        );
 
         let rewrite = ToolCallInfo {
             id: "rewrite-temp-script".into(),

--- a/ovim-core/src/editor/ai_chat_turn.rs
+++ b/ovim-core/src/editor/ai_chat_turn.rs
@@ -743,6 +743,10 @@ impl Editor {
             );
             return;
         };
+        if self.current_session_authorizes_temp_shell_command(&command) {
+            self.execute_dynamic_tool_after_policy(turn, tool, call, response, None, false);
+            return;
+        }
         let request = ClassifierRequest::new(
             ShellProposal {
                 command,
@@ -1004,6 +1008,8 @@ impl Editor {
         let task_command = command.clone();
         let task_workdir = workdir.clone();
         let task = tokio::task::spawn_blocking(move || {
+            let temp_probe =
+                super::ai_session_temp::TempPathProbe::for_shell_command(&task_command);
             let observation = match crate::run_log::capture_workspace(&task_workdir, &artifact_store) {
                 Ok(before) => {
                     let result = super::ai_tool_execution::run_bash_program(
@@ -1018,12 +1024,14 @@ impl Editor {
                         Ok(after) => super::ai_chat_state::ShellExecutionObservation {
                             result,
                             delta: Some(before.diff(after)),
+                            created_temp_files: temp_probe.created_files(),
                             capture_error: None,
                             outcome_unknown: false,
                         },
                         Err(error) => super::ai_chat_state::ShellExecutionObservation {
                             result,
                             delta: None,
+                            created_temp_files: Vec::new(),
                             capture_error: Some(format!(
                                 "shell completed, but after-state capture failed: {error}"
                             )),
@@ -1036,6 +1044,7 @@ impl Editor {
                         "shell program was not executed because before-state capture failed: {error}"
                     )),
                     delta: None,
+                    created_temp_files: Vec::new(),
                     capture_error: Some(error),
                     outcome_unknown: false,
                 },
@@ -1104,6 +1113,7 @@ impl Editor {
                             "shell execution task stopped without a result".into(),
                         ),
                         delta: None,
+                        created_temp_files: Vec::new(),
                         capture_error: Some(
                             "shell execution and workspace result are unknown".into(),
                         ),
@@ -1119,6 +1129,9 @@ impl Editor {
             .and_then(|chat| chat.pending_shell_execution.take())
             .expect("pending shell exists");
         let observation = received.expect("shell result");
+        for path in &observation.created_temp_files {
+            self.record_current_session_temp_file(path);
+        }
         if let Some(chat) = self.ai_state.chat.as_mut() {
             let phase = if observation.outcome_unknown {
                 super::ai_chat_state::ShellTranscriptPhase::OutcomeUnknown

--- a/ovim-core/src/editor/ai_codex_auth.rs
+++ b/ovim-core/src/editor/ai_codex_auth.rs
@@ -4,9 +4,24 @@ use crate::{KeyCode, KeyEvent};
 
 use super::ai_state::{
     CodexAuthDialog, CodexAuthDialogPhase, CodexAuthDialogSummary, CodexAuthResume,
-    PendingCodexAuth,
+    PendingCodexAuth, PendingCodexAuthReceiver,
 };
 use super::Editor;
+
+enum PendingCodexAuthOutcome {
+    Completion(anyhow::Result<()>),
+    DeviceCode(anyhow::Result<codex_auth::DeviceLoginCode>),
+}
+
+fn is_ssh_session() -> bool {
+    is_ssh_session_with(|name| std::env::var_os(name))
+}
+
+fn is_ssh_session_with(mut value: impl FnMut(&str) -> Option<std::ffi::OsString>) -> bool {
+    ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]
+        .into_iter()
+        .any(|name| value(name).is_some_and(|value| !value.is_empty()))
+}
 
 impl Editor {
     pub fn codex_auth_dialog_summary(&self) -> Option<CodexAuthDialogSummary> {
@@ -14,6 +29,8 @@ impl Editor {
         Some(CodexAuthDialogSummary {
             phase: dialog.phase.clone(),
             detail: dialog.detail.clone(),
+            authorize_url: dialog.authorize_url.clone(),
+            user_code: dialog.user_code.clone(),
         })
     }
 
@@ -67,6 +84,7 @@ impl Editor {
                     phase: CodexAuthDialogPhase::Offer,
                     detail: Some(detail),
                     authorize_url: None,
+                    user_code: None,
                     resume,
                 });
                 false
@@ -83,9 +101,13 @@ impl Editor {
             phase: CodexAuthDialogPhase::Refreshing,
             detail: None,
             authorize_url: None,
+            user_code: None,
             resume,
         });
-        self.ai_state.pending_codex_auth = Some(PendingCodexAuth { receiver, task });
+        self.ai_state.pending_codex_auth = Some(PendingCodexAuth {
+            receiver: PendingCodexAuthReceiver::Completion(receiver),
+            task,
+        });
     }
 
     fn start_codex_browser_login(&mut self) {
@@ -97,9 +119,10 @@ impl Editor {
                     dialog.phase = CodexAuthDialogPhase::WaitingForBrowser;
                     dialog.detail = None;
                     dialog.authorize_url = Some(attempt.authorize_url);
+                    dialog.user_code = None;
                 }
                 self.ai_state.pending_codex_auth = Some(PendingCodexAuth {
-                    receiver: attempt.receiver,
+                    receiver: PendingCodexAuthReceiver::Completion(attempt.receiver),
                     task: attempt.task,
                 });
             }
@@ -108,8 +131,35 @@ impl Editor {
                     dialog.phase = CodexAuthDialogPhase::Error;
                     dialog.detail = Some(error.to_string());
                     dialog.authorize_url = None;
+                    dialog.user_code = None;
                 }
             }
+        }
+    }
+
+    fn start_codex_device_login(&mut self) {
+        self.ai_state.pending_codex_auth = None;
+        let (tx, receiver) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _ = tx.send(codex_auth::request_device_login().await);
+        });
+        if let Some(dialog) = self.ai_state.codex_auth_dialog.as_mut() {
+            dialog.phase = CodexAuthDialogPhase::PreparingDeviceCode;
+            dialog.detail = None;
+            dialog.authorize_url = None;
+            dialog.user_code = None;
+        }
+        self.ai_state.pending_codex_auth = Some(PendingCodexAuth {
+            receiver: PendingCodexAuthReceiver::DeviceCode(receiver),
+            task,
+        });
+    }
+
+    fn start_preferred_codex_login(&mut self) {
+        if is_ssh_session() {
+            self.start_codex_device_login();
+        } else {
+            self.start_codex_browser_login();
         }
     }
 
@@ -129,6 +179,18 @@ impl Editor {
                 );
             }
             (Some(CodexAuthDialogPhase::Offer | CodexAuthDialogPhase::Error), KeyCode::Enter) => {
+                self.start_preferred_codex_login();
+            }
+            (
+                Some(CodexAuthDialogPhase::Offer | CodexAuthDialogPhase::Error),
+                KeyCode::Char('d' | 'D'),
+            ) => {
+                self.start_codex_device_login();
+            }
+            (
+                Some(CodexAuthDialogPhase::Offer | CodexAuthDialogPhase::Error),
+                KeyCode::Char('b' | 'B'),
+            ) => {
                 self.start_codex_browser_login();
             }
             (Some(CodexAuthDialogPhase::WaitingForBrowser), KeyCode::Char('o' | 'O')) => {
@@ -147,12 +209,25 @@ impl Editor {
             let Some(pending) = self.ai_state.pending_codex_auth.as_mut() else {
                 return false;
             };
-            match pending.receiver.try_recv() {
-                Ok(result) => Some(result),
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
-                Err(tokio::sync::oneshot::error::TryRecvError::Closed) => Some(Err(
-                    anyhow::anyhow!("Codex sign-in task stopped unexpectedly"),
-                )),
+            match &mut pending.receiver {
+                PendingCodexAuthReceiver::Completion(receiver) => match receiver.try_recv() {
+                    Ok(result) => Some(PendingCodexAuthOutcome::Completion(result)),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                        Some(PendingCodexAuthOutcome::Completion(Err(anyhow::anyhow!(
+                            "Codex sign-in task stopped unexpectedly"
+                        ))))
+                    }
+                },
+                PendingCodexAuthReceiver::DeviceCode(receiver) => match receiver.try_recv() {
+                    Ok(result) => Some(PendingCodexAuthOutcome::DeviceCode(result)),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                        Some(PendingCodexAuthOutcome::DeviceCode(Err(anyhow::anyhow!(
+                            "Codex device sign-in task stopped unexpectedly"
+                        ))))
+                    }
+                },
             }
         };
         let Some(outcome) = outcome else {
@@ -161,7 +236,23 @@ impl Editor {
         self.ai_state.pending_codex_auth = None;
 
         match outcome {
-            Ok(()) => {
+            PendingCodexAuthOutcome::DeviceCode(Ok(code)) => {
+                if let Some(dialog) = self.ai_state.codex_auth_dialog.as_mut() {
+                    dialog.phase = CodexAuthDialogPhase::WaitingForDeviceCode;
+                    dialog.detail = None;
+                    dialog.authorize_url = Some(code.verification_url.clone());
+                    dialog.user_code = Some(code.user_code.clone());
+                }
+                let (tx, receiver) = tokio::sync::oneshot::channel();
+                let task = tokio::spawn(async move {
+                    let _ = tx.send(codex_auth::complete_device_login(code).await);
+                });
+                self.ai_state.pending_codex_auth = Some(PendingCodexAuth {
+                    receiver: PendingCodexAuthReceiver::Completion(receiver),
+                    task,
+                });
+            }
+            PendingCodexAuthOutcome::Completion(Ok(())) => {
                 let resume = self
                     .ai_state
                     .codex_auth_dialog
@@ -171,11 +262,13 @@ impl Editor {
                 self.set_status_message("Signed in to Codex for Ovim");
                 self.resume_after_codex_auth(resume);
             }
-            Err(error) => {
+            PendingCodexAuthOutcome::Completion(Err(error))
+            | PendingCodexAuthOutcome::DeviceCode(Err(error)) => {
                 if let Some(dialog) = self.ai_state.codex_auth_dialog.as_mut() {
                     dialog.phase = CodexAuthDialogPhase::Error;
                     dialog.detail = Some(error.to_string());
                     dialog.authorize_url = None;
+                    dialog.user_code = None;
                 }
             }
         }
@@ -223,6 +316,7 @@ mod tests {
             phase: CodexAuthDialogPhase::Offer,
             detail: None,
             authorize_url: None,
+            user_code: None,
             resume: CodexAuthResume::None,
         });
         editor.handle_codex_auth_key(KeyEvent {
@@ -243,6 +337,7 @@ mod tests {
             phase: CodexAuthDialogPhase::WaitingForBrowser,
             detail: None,
             authorize_url: Some("https://example.test/login".into()),
+            user_code: None,
             resume: CodexAuthResume::None,
         });
         editor.handle_codex_auth_key(KeyEvent {
@@ -307,5 +402,33 @@ mod tests {
 
         assert_eq!(editor.mode(), Mode::Normal);
         assert!(editor.has_codex_auth_dialog());
+    }
+
+    #[test]
+    fn ssh_detection_accepts_any_nonempty_ssh_marker() {
+        let detected =
+            is_ssh_session_with(|name| (name == "SSH_CONNECTION").then(|| "client server".into()));
+        assert!(detected);
+        assert!(!is_ssh_session_with(|_| None));
+        assert!(!is_ssh_session_with(|_| Some("".into())));
+    }
+
+    #[test]
+    fn dialog_summary_exposes_device_code_without_internal_polling_state() {
+        let mut editor = Editor::default();
+        editor.ai_state.codex_auth_dialog = Some(CodexAuthDialog {
+            phase: CodexAuthDialogPhase::WaitingForDeviceCode,
+            detail: None,
+            authorize_url: Some("https://auth.example/device".into()),
+            user_code: Some("ABCD-EFGH".into()),
+            resume: CodexAuthResume::None,
+        });
+
+        let summary = editor.codex_auth_dialog_summary().unwrap();
+        assert_eq!(
+            summary.authorize_url.as_deref(),
+            Some("https://auth.example/device")
+        );
+        assert_eq!(summary.user_code.as_deref(), Some("ABCD-EFGH"));
     }
 }

--- a/ovim-core/src/editor/ai_session_temp.rs
+++ b/ovim-core/src/editor/ai_session_temp.rs
@@ -29,6 +29,9 @@ impl TempFileIdentity {
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
+            if metadata.nlink() != 1 {
+                return None;
+            }
             Some(Self {
                 device: metadata.dev(),
                 inode: metadata.ino(),
@@ -87,6 +90,12 @@ impl SessionTempFiles {
             return words[1..]
                 .iter()
                 .all(|word| self.argument_stays_in_scope(word, project_root));
+        }
+
+        // Interpreter and utility exemptions only apply to normal PATH lookups. An
+        // arbitrary executable named `bash` or `chmod` must not inherit authority.
+        if program_path.is_absolute() || program.contains(['/', '\\']) {
+            return false;
         }
 
         let program_name = program_path
@@ -266,6 +275,22 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn hard_linking_a_recorded_file_revokes_authority() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        let alias = directory.path().join("alias.sh");
+        fs::write(&file, "#!/bin/sh\n").unwrap();
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+
+        fs::hard_link(&file, &alias).unwrap();
+        assert!(!files.contains(&file));
+        assert!(!files.contains(&alias));
+        assert!(!files.record(&alias));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn canonical_temp_aliases_share_the_same_authority() {
         let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
         let file = directory.path().join("owned.sh");
@@ -328,5 +353,12 @@ mod tests {
         ));
         assert!(!files
             .authorizes_shell_command(&format!("{} ../outside", script.display()), project.path()));
+
+        let fake_bash = directory.path().join("bash");
+        fs::write(&fake_bash, "#!/bin/sh\n").unwrap();
+        assert!(!files.authorizes_shell_command(
+            &format!("{} {}", fake_bash.display(), script.display()),
+            project.path()
+        ));
     }
 }

--- a/ovim-core/src/editor/ai_session_temp.rs
+++ b/ovim-core/src/editor/ai_session_temp.rs
@@ -1,0 +1,332 @@
+use crate::ai::path_policy::canonicalize_or_normalize;
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+/// Exact temporary files created by the active chat session.
+///
+/// This is intentionally an exact-file registry, not an allowlist for the
+/// system temp directory. File identity is revalidated on Unix so replacing a
+/// recorded path does not inherit the session's authority.
+#[derive(Debug, Default)]
+pub(super) struct SessionTempFiles {
+    files: HashMap<PathBuf, TempFileIdentity>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TempFileIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl TempFileIdentity {
+    fn read(path: &Path) -> Option<Self> {
+        let metadata = std::fs::metadata(path).ok()?;
+        if !metadata.is_file() {
+            return None;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Some(Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Some(Self {})
+        }
+    }
+}
+
+impl SessionTempFiles {
+    pub(super) fn record(&mut self, path: &Path) -> bool {
+        let Some(path) = canonical_temp_file(path) else {
+            return false;
+        };
+        let Some(identity) = TempFileIdentity::read(&path) else {
+            return false;
+        };
+        self.files.insert(path, identity);
+        true
+    }
+
+    pub(super) fn contains(&self, path: &Path) -> bool {
+        let Some(path) = canonical_temp_file(path) else {
+            return false;
+        };
+        let Some(expected) = self.files.get(&path) else {
+            return false;
+        };
+        TempFileIdentity::read(&path).as_ref() == Some(expected)
+    }
+
+    /// Return true for the narrow shell forms needed to make or run a
+    /// session-created temp file. General shell programs still use normal auto
+    /// mode because an owned file argument must not authorize unrelated
+    /// external effects in the same command.
+    pub(super) fn authorizes_shell_command(&self, command: &str, project_root: &Path) -> bool {
+        if command.chars().any(|character| {
+            matches!(
+                character,
+                '|' | '&' | ';' | '>' | '<' | '\n' | '`' | '$' | '(' | ')'
+            )
+        }) {
+            return false;
+        }
+        let Some(words) = shlex::split(command) else {
+            return false;
+        };
+        let Some(program) = words.first() else {
+            return false;
+        };
+        let program_path = Path::new(program);
+        if program_path.is_absolute() && self.contains(program_path) {
+            return words[1..]
+                .iter()
+                .all(|word| self.argument_stays_in_scope(word, project_root));
+        }
+
+        let program_name = program_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(program);
+        match program_name {
+            "chmod" => {
+                let Some((mode, targets)) = words[1..].split_first() else {
+                    return false;
+                };
+                is_simple_chmod_mode(mode)
+                    && !targets.is_empty()
+                    && targets
+                        .iter()
+                        .all(|target| self.contains(Path::new(target)))
+            }
+            "sh" | "bash" | "zsh" | "python" | "python3" | "node" | "ruby" | "perl" => {
+                let Some(script) = words[1..].iter().find(|word| !word.starts_with('-')) else {
+                    return false;
+                };
+                self.contains(Path::new(script))
+                    && words
+                        .iter()
+                        .skip_while(|word| *word != script)
+                        .skip(1)
+                        .all(|word| self.argument_stays_in_scope(word, project_root))
+            }
+            _ => false,
+        }
+    }
+
+    fn argument_stays_in_scope(&self, word: &str, project_root: &Path) -> bool {
+        let candidate = word.split_once('=').map_or(word, |(_, value)| value);
+        let path = Path::new(candidate);
+        if path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+        {
+            return false;
+        }
+        if !path.is_absolute() {
+            return true;
+        }
+        let path = canonicalize_or_normalize(path);
+        path.starts_with(canonicalize_or_normalize(project_root)) || self.contains(&path)
+    }
+}
+
+fn is_simple_chmod_mode(mode: &str) -> bool {
+    (!mode.is_empty() && mode.chars().all(|character| character.is_ascii_digit()))
+        || (mode.contains(['+', '-', '='])
+            && mode.chars().all(|character| {
+                matches!(
+                    character,
+                    'u' | 'g' | 'o' | 'a' | '+' | '-' | '=' | 'r' | 'w' | 'x' | 'X' | 's' | 't'
+                )
+            }))
+}
+
+/// Snapshot the literal temp paths named by a shell command. Only paths that
+/// did not exist before the command and are regular files afterwards are
+/// returned. This avoids scanning shared temp directories or attributing
+/// another process's unrelated files to the agent session.
+pub(super) struct TempPathProbe {
+    missing_candidates: Vec<PathBuf>,
+}
+
+impl TempPathProbe {
+    pub(super) fn for_shell_command(command: &str) -> Self {
+        let missing_candidates = shell_temp_path_candidates(command)
+            .into_iter()
+            .filter(|path| !path.exists())
+            .collect();
+        Self { missing_candidates }
+    }
+
+    pub(super) fn created_files(self) -> Vec<PathBuf> {
+        self.missing_candidates
+            .into_iter()
+            .filter_map(|path| canonical_temp_file(&path))
+            .collect()
+    }
+}
+
+fn shell_temp_path_candidates(command: &str) -> Vec<PathBuf> {
+    let mut candidates = BTreeSet::new();
+    for token in crate::ai::auto_mode::shell_tokens(command) {
+        let mut values = vec![token.as_str()];
+        if let Some((_, value)) = token.split_once('=') {
+            values.push(value);
+        }
+        for value in values {
+            let value = value.trim_matches(|character: char| {
+                matches!(character, ',' | ':' | '[' | ']' | '{' | '}')
+            });
+            let expanded = expand_temp_variable(value);
+            let path = Path::new(&expanded);
+            if path.is_absolute() && is_temp_location(path) {
+                candidates.insert(canonicalize_or_normalize(path));
+            }
+        }
+    }
+    candidates.into_iter().collect()
+}
+
+fn expand_temp_variable(value: &str) -> String {
+    for prefix in ["$TMPDIR", "${TMPDIR}", "$TEMP", "${TEMP}", "$TMP", "${TMP}"] {
+        if let Some(suffix) = value.strip_prefix(prefix) {
+            return std::env::temp_dir()
+                .join(suffix.trim_start_matches(['/', '\\']))
+                .to_string_lossy()
+                .into_owned();
+        }
+    }
+    value.to_string()
+}
+
+fn canonical_temp_file(path: &Path) -> Option<PathBuf> {
+    let path = path.canonicalize().ok()?;
+    (path.is_file() && is_temp_location(&path)).then_some(path)
+}
+
+pub(super) fn is_temp_location(path: &Path) -> bool {
+    let path = canonicalize_or_normalize(path);
+    temp_roots()
+        .into_iter()
+        .any(|root| path != root && path.starts_with(root))
+}
+
+fn temp_roots() -> Vec<PathBuf> {
+    let mut roots = BTreeSet::new();
+    roots.insert(canonicalize_or_normalize(&std::env::temp_dir()));
+    #[cfg(unix)]
+    for conventional in ["/tmp", "/var/tmp", "/private/tmp"] {
+        let path = Path::new(conventional);
+        if path.is_dir() {
+            roots.insert(canonicalize_or_normalize(path));
+        }
+    }
+    roots.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn records_only_exact_regular_temp_files() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        fs::write(&file, "#!/bin/sh\n").unwrap();
+        let sibling = directory.path().join("not-owned.sh");
+        fs::write(&sibling, "#!/bin/sh\n").unwrap();
+
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+        assert!(files.contains(&file));
+        assert!(!files.contains(&sibling));
+        assert!(!files.contains(directory.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacing_a_recorded_inode_revokes_authority() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        fs::write(&file, "old\n").unwrap();
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+
+        fs::remove_file(&file).unwrap();
+        fs::write(&file, "replacement\n").unwrap();
+        assert!(!files.contains(&file));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_temp_aliases_share_the_same_authority() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let file = directory.path().join("owned.sh");
+        fs::write(&file, "#!/bin/sh\n").unwrap();
+        let alias = directory.path().with_extension("alias");
+        std::os::unix::fs::symlink(directory.path(), &alias).unwrap();
+        let alias_file = alias.join("owned.sh");
+
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&file));
+        assert!(files.contains(&alias_file));
+        fs::remove_file(alias).unwrap();
+    }
+
+    #[test]
+    fn probe_attributes_only_new_literal_temp_files() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let existing = directory.path().join("existing");
+        let created = directory.path().join("created");
+        fs::write(&existing, "before\n").unwrap();
+        let command = format!(
+            "printf after > {} && printf new > {}",
+            existing.display(),
+            created.display()
+        );
+        let probe = TempPathProbe::for_shell_command(&command);
+        fs::write(&existing, "after\n").unwrap();
+        fs::write(&created, "new\n").unwrap();
+
+        assert_eq!(probe.created_files(), vec![created.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn authorizes_only_narrow_owned_file_shell_forms() {
+        let directory = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
+        let script = directory.path().join("owned.sh");
+        fs::write(&script, "#!/bin/sh\n").unwrap();
+        let mut files = SessionTempFiles::default();
+        assert!(files.record(&script));
+        let project = tempfile::tempdir().unwrap();
+
+        assert!(files
+            .authorizes_shell_command(&format!("chmod +x {}", script.display()), project.path()));
+        assert!(files.authorizes_shell_command(&script.display().to_string(), project.path()));
+        assert!(files.authorizes_shell_command(
+            &format!("bash {} --check", script.display()),
+            project.path()
+        ));
+        assert!(!files.authorizes_shell_command(
+            &format!("{}; curl https://example.test", script.display()),
+            project.path()
+        ));
+        assert!(!files.authorizes_shell_command(
+            &format!("chmod +x {}/unowned", directory.path().display()),
+            project.path()
+        ));
+        assert!(!files.authorizes_shell_command(
+            &format!("chmod --reference=/etc/passwd {}", script.display()),
+            project.path()
+        ));
+        assert!(!files
+            .authorizes_shell_command(&format!("{} ../outside", script.display()), project.path()));
+    }
+}

--- a/ovim-core/src/editor/ai_state.rs
+++ b/ovim-core/src/editor/ai_state.rs
@@ -47,6 +47,8 @@ pub struct AiSelectionSnapshot {
 pub enum CodexAuthDialogPhase {
     Offer,
     Refreshing,
+    PreparingDeviceCode,
+    WaitingForDeviceCode,
     WaitingForBrowser,
     Error,
 }
@@ -55,6 +57,8 @@ pub enum CodexAuthDialogPhase {
 pub struct CodexAuthDialogSummary {
     pub phase: CodexAuthDialogPhase,
     pub detail: Option<String>,
+    pub authorize_url: Option<String>,
+    pub user_code: Option<String>,
 }
 
 #[derive(Debug)]
@@ -67,11 +71,19 @@ pub(crate) struct CodexAuthDialog {
     pub phase: CodexAuthDialogPhase,
     pub detail: Option<String>,
     pub authorize_url: Option<String>,
+    pub user_code: Option<String>,
     pub resume: CodexAuthResume,
 }
 
+pub(crate) enum PendingCodexAuthReceiver {
+    Completion(tokio::sync::oneshot::Receiver<anyhow::Result<()>>),
+    DeviceCode(
+        tokio::sync::oneshot::Receiver<anyhow::Result<crate::ai::codex_auth::DeviceLoginCode>>,
+    ),
+}
+
 pub(crate) struct PendingCodexAuth {
-    pub receiver: tokio::sync::oneshot::Receiver<anyhow::Result<()>>,
+    pub receiver: PendingCodexAuthReceiver,
     pub task: tokio::task::JoinHandle<()>,
 }
 

--- a/ovim-core/src/editor/ai_tool_path.rs
+++ b/ovim-core/src/editor/ai_tool_path.rs
@@ -61,6 +61,17 @@ impl Editor {
             .is_some_and(|root| requested_path.starts_with(root));
         let approved_session_match = self.current_session_approved_root_for(&requested_path);
 
+        // A session owns only the exact temp files it created. This check is
+        // deliberately before the project boundary prompt but after
+        // canonicalization, so platform aliases such as /tmp and /private/tmp
+        // resolve to the same file without granting the surrounding folder.
+        if self.current_session_created_temp_file(&requested_path) {
+            return Ok(ToolPathResolution::Allowed {
+                absolute_path: requested_path.clone(),
+                boundary_root: requested_path,
+            });
+        }
+
         if requested_path.starts_with(&boundary_root) {
             if let Some(reason) = sensitive_path_reason(&requested_path) {
                 let approved_sensitive = self.ai_chat_yolo_mode()
@@ -160,6 +171,30 @@ impl Editor {
         None
     }
 
+    pub(super) fn current_session_created_temp_file(&self, path: &Path) -> bool {
+        self.ai_state
+            .chat
+            .as_ref()
+            .is_some_and(|chat| chat.created_temp_files.contains(path))
+    }
+
+    pub(super) fn record_current_session_temp_file(&mut self, path: &Path) -> bool {
+        self.ai_state
+            .chat
+            .as_mut()
+            .is_some_and(|chat| chat.created_temp_files.record(path))
+    }
+
+    pub(super) fn current_session_authorizes_temp_shell_command(&self, command: &str) -> bool {
+        let Some(project_root) = self.ai_effective_project_root() else {
+            return false;
+        };
+        self.ai_state.chat.as_ref().is_some_and(|chat| {
+            chat.created_temp_files
+                .authorizes_shell_command(command, &project_root)
+        })
+    }
+
     /// Effective project boundary for AI project-level tools.
     ///
     /// Prefers git repository root. Outside git, falls back to a
@@ -190,7 +225,20 @@ impl Editor {
             .map(PathBuf::from);
         let current_file = self.buffer().file_path().map(PathBuf::from);
 
-        if let Some(file) = active_target_file.or(origin_file).or(current_file) {
+        // Opening a temp artifact as the mutation target must not replace the
+        // chat's repository boundary. Keep resolving policy and capabilities
+        // from the originating project while that exact artifact is active.
+        let active_target_is_unscoped_temp = active_target_file.as_deref().is_some_and(|path| {
+            super::ai_session_temp::is_temp_location(path)
+                && discover_repo_root_from_start(path).is_none()
+        });
+        let target_file = if active_target_is_unscoped_temp {
+            origin_file.or(active_target_file)
+        } else {
+            active_target_file.or(origin_file)
+        };
+
+        if let Some(file) = target_file.or(current_file) {
             Some(self.absolutize_path(&file))
         } else {
             std::env::current_dir().ok()

--- a/ovim-core/src/editor/ai_tool_path.rs
+++ b/ovim-core/src/editor/ai_tool_path.rs
@@ -228,11 +228,10 @@ impl Editor {
         // Opening a temp artifact as the mutation target must not replace the
         // chat's repository boundary. Keep resolving policy and capabilities
         // from the originating project while that exact artifact is active.
-        let active_target_is_unscoped_temp = active_target_file.as_deref().is_some_and(|path| {
-            super::ai_session_temp::is_temp_location(path)
-                && discover_repo_root_from_start(path).is_none()
-        });
-        let target_file = if active_target_is_unscoped_temp {
+        let active_target_is_session_temp = active_target_file
+            .as_deref()
+            .is_some_and(|path| self.current_session_created_temp_file(path));
+        let target_file = if active_target_is_session_temp {
             origin_file.or(active_target_file)
         } else {
             active_target_file.or(origin_file)

--- a/ovim-core/src/editor/mod.rs
+++ b/ovim-core/src/editor/mod.rs
@@ -23,6 +23,7 @@ mod ai_comprehension;
 mod ai_durable_chat;
 pub(crate) mod ai_integration;
 mod ai_run_events;
+mod ai_session_temp;
 mod ai_shell_process;
 mod ai_skills;
 mod ai_state;

--- a/ovim-core/src/lua/editor_bridge.rs
+++ b/ovim-core/src/lua/editor_bridge.rs
@@ -312,7 +312,7 @@ impl EditorBridge {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        inner.pending_commands.drain(..).collect()
+        std::mem::take(&mut inner.pending_commands)
     }
 
     /// Get a specific line from the buffer
@@ -388,7 +388,7 @@ impl EditorBridge {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        inner.ai_pending_commands.drain(..).collect()
+        std::mem::take(&mut inner.ai_pending_commands)
     }
 
     pub fn register_api_key(&self, name: String, config: ApiKeyConfig) {

--- a/ovim-core/src/run_log/artifact.rs
+++ b/ovim-core/src/run_log/artifact.rs
@@ -70,7 +70,7 @@ impl FromStr for BlobId {
         }
 
         let mut bytes = [0; 32];
-        for (index, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
+        for (index, pair) in hex.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             bytes[index] = (hex_digit(pair[0]).ok_or(InvalidBlobId::InvalidHex)? << 4)
                 | hex_digit(pair[1]).ok_or(InvalidBlobId::InvalidHex)?;
         }

--- a/ovim/src/api/mod.rs
+++ b/ovim/src/api/mod.rs
@@ -10,13 +10,13 @@ pub use state::{
     format_context_window, parse_key_string, AgentArtifactHandle, AgentArtifactsResponse,
     AgentControlPlaneSnapshot, AgentControlResponse, AgentControlTarget, AgentEventsResponse,
     AgentSnapshot, AiChatMessageSnapshot, AiChatSnapshot, ApiRequest, ApiResponse, ApiState,
-    BufferInfo, CodeExplanationSnapshot, ContextWindowInfo, CursorPosition, DecorationInfo,
-    DiagnosticCounts, DiagnosticItem, DiagnosticsInfo, EditorSnapshot, ErrorResponse, HealthInfo,
-    ImageAttachmentSnapshot, LineEntry, LinesResponse, LspServerInfoItem, LspStatusInfo,
-    MetricsInfo, ModeInfo, OutlineInfo, OutlineSymbol, PickerInfo, PickerResultInfo,
-    QueuedChatSnapshot, RenderInfo, SendKeysResult, SuccessResponse, SymbolSearchInfo,
-    SymbolSearchResult, ToolCallSnapshot, TraceInfo, TraceNode, ViewSnapshot, VisualSelection,
-    AGENT_API_SCHEMA_VERSION, SNAPSHOT_SCHEMA_VERSION,
+    BufferInfo, CodeExplanationSnapshot, CodexAuthSnapshot, ContextWindowInfo, CursorPosition,
+    DecorationInfo, DiagnosticCounts, DiagnosticItem, DiagnosticsInfo, EditorSnapshot,
+    ErrorResponse, HealthInfo, ImageAttachmentSnapshot, LineEntry, LinesResponse,
+    LspServerInfoItem, LspStatusInfo, MetricsInfo, ModeInfo, OutlineInfo, OutlineSymbol,
+    PickerInfo, PickerResultInfo, QueuedChatSnapshot, RenderInfo, SendKeysResult, SuccessResponse,
+    SymbolSearchInfo, SymbolSearchResult, ToolCallSnapshot, TraceInfo, TraceNode, ViewSnapshot,
+    VisualSelection, AGENT_API_SCHEMA_VERSION, SNAPSHOT_SCHEMA_VERSION,
 };
 
 use anyhow::Result;

--- a/ovim/src/api/state.rs
+++ b/ovim/src/api/state.rs
@@ -285,11 +285,28 @@ pub struct AiChatSnapshot {
     /// Blocking first-run/recovery setup currently shown by the chat UI.
     #[serde(default)]
     pub pending_setup: Option<String>,
+    /// Active Codex sign-in state. Device-code fields let SSH/headless clients
+    /// complete login without scraping terminal rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_auth: Option<CodexAuthSnapshot>,
     /// Interactive concept/code walkthrough currently blocking the agent tool call.
     #[serde(default)]
     pub code_explanation: Option<CodeExplanationSnapshot>,
     pub queued: Vec<QueuedChatSnapshot>,
     pub messages: Vec<AiChatMessageSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexAuthSnapshot {
+    /// `offer`, `refreshing`, `preparing_device_code`,
+    /// `waiting_for_device_code`, `waiting_for_browser`, or `error`.
+    pub phase: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ovim/src/api_dispatch.rs
+++ b/ovim/src/api_dispatch.rs
@@ -1072,8 +1072,8 @@ pub(crate) fn create_snapshot_with_dimensions(
 
 fn create_ai_chat_snapshot(editor: &Editor) -> Option<ovim::api::AiChatSnapshot> {
     use ovim::api::{
-        AiChatMessageSnapshot, AiChatSnapshot, CodeExplanationSnapshot, QueuedChatSnapshot,
-        ToolCallSnapshot,
+        AiChatMessageSnapshot, AiChatSnapshot, CodeExplanationSnapshot, CodexAuthSnapshot,
+        QueuedChatSnapshot, ToolCallSnapshot,
     };
     use ovim_core::ai::chat_types::{ChatFocus, ChatRole};
     use ovim_core::editor::QueuedChatInputKind;
@@ -1082,6 +1082,24 @@ fn create_ai_chat_snapshot(editor: &Editor) -> Option<ovim::api::AiChatSnapshot>
     let pending_approval = editor
         .ai_chat_pending_tool_approval_summary()
         .or_else(|| editor.ai_chat_pending_no_repo_folder_approval_summary());
+    let codex_auth = editor.codex_auth_dialog_summary().map(|summary| {
+        use ovim_core::editor::CodexAuthDialogPhase;
+
+        CodexAuthSnapshot {
+            phase: match summary.phase {
+                CodexAuthDialogPhase::Offer => "offer",
+                CodexAuthDialogPhase::Refreshing => "refreshing",
+                CodexAuthDialogPhase::PreparingDeviceCode => "preparing_device_code",
+                CodexAuthDialogPhase::WaitingForDeviceCode => "waiting_for_device_code",
+                CodexAuthDialogPhase::WaitingForBrowser => "waiting_for_browser",
+                CodexAuthDialogPhase::Error => "error",
+            }
+            .to_string(),
+            detail: summary.detail,
+            verification_url: summary.authorize_url,
+            user_code: summary.user_code,
+        }
+    });
     let queued = editor
         .ai_chat_queued_inputs()
         .map(|item| QueuedChatSnapshot {
@@ -1168,6 +1186,7 @@ fn create_ai_chat_snapshot(editor: &Editor) -> Option<ovim::api::AiChatSnapshot>
                     editor.ai_chat_exa_dashboard_url()
                 )
             }),
+        codex_auth,
         code_explanation: editor
             .ai_code_explanation_view()
             .map(|view| {

--- a/ovim/src/ui/renderer/overlays.rs
+++ b/ovim/src/ui/renderer/overlays.rs
@@ -627,7 +627,10 @@ pub fn render_codex_auth_dialog(frame: &mut Frame, editor: &Editor) {
                 ),
                 (detail.as_str(), 's'),
                 (" ", 's'),
-                ("Enter: sign in in browser   Esc: not now", 'a'),
+                (
+                    "Enter: sign in   D: device code (SSH)   B: browser   Esc: not now",
+                    'a',
+                ),
             ],
         ),
         CodexAuthDialogPhase::Refreshing => render_modal_dialog(
@@ -640,6 +643,36 @@ pub fn render_codex_auth_dialog(frame: &mut Frame, editor: &Editor) {
                 ("Esc: cancel", 'a'),
             ],
         ),
+        CodexAuthDialogPhase::PreparingDeviceCode => render_modal_dialog(
+            frame,
+            " Preparing Device Sign-in ",
+            &[
+                ("Requesting a one-time sign-in code…", 't'),
+                ("This works over SSH and on headless machines.", 's'),
+                (" ", 's'),
+                ("Esc: cancel", 'a'),
+            ],
+        ),
+        CodexAuthDialogPhase::WaitingForDeviceCode => {
+            let url = summary.authorize_url.unwrap_or_default();
+            let code = summary.user_code.unwrap_or_default();
+            render_modal_dialog(
+                frame,
+                " Finish Codex Device Sign-in ",
+                &[
+                    ("1. Open this URL in any browser:", 't'),
+                    (url.as_str(), 's'),
+                    ("2. Enter this one-time code (expires in 15 minutes):", 't'),
+                    (code.as_str(), 'a'),
+                    (
+                        "Continue only if you started this login in Ovim. If someone else gave you this code, cancel.",
+                        's',
+                    ),
+                    (" ", 's'),
+                    ("Waiting for approval…   Esc: cancel", 'a'),
+                ],
+            );
+        }
         CodexAuthDialogPhase::WaitingForBrowser => render_modal_dialog(
             frame,
             " Finish Sign-in in Your Browser ",
@@ -657,7 +690,10 @@ pub fn render_codex_auth_dialog(frame: &mut Frame, editor: &Editor) {
                 (detail.as_str(), 't'),
                 ("Your draft and selection are still here.", 's'),
                 (" ", 's'),
-                ("Enter: try again   Esc: cancel", 'a'),
+                (
+                    "Enter: try again   D: device code   B: browser   Esc: cancel",
+                    'a',
+                ),
             ],
         ),
     }
@@ -1608,7 +1644,10 @@ mod tests {
                             's',
                         ),
                         (" ", 's'),
-                        ("Enter: sign in in browser   Esc: not now", 'a'),
+                        (
+                            "Enter: sign in   D: device code (SSH)   B: browser   Esc: not now",
+                            'a',
+                        ),
                     ],
                 )
             })
@@ -1621,7 +1660,7 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect::<String>();
-        assert!(rendered.contains("Enter: sign in in browser"), "{rendered}");
+        assert!(rendered.contains("Enter: sign in"), "{rendered}");
     }
 
     #[test]

--- a/user-docs/ai.md
+++ b/user-docs/ai.md
@@ -72,6 +72,15 @@ read-only inputs and do not trigger outside-project approval prompts. To opt
 out of auto mode, set `tool_approval_mode = "sensitive_prompt"` or
 `"always_prompt"` in legacy `ai.toml`.
 
+An exact temporary file created by the active chat keeps that session's
+authority for later reads, edits, `chmod +x`, and execution. Ovim uses the
+platform temp directory and canonical paths, so aliases such as macOS `/tmp`
+and `/private/tmp` identify the same file. The grant never expands to the
+surrounding temp folder or a sibling file, and replacing the recorded file on
+Unix revokes it. Shell attribution considers only previously absent temp paths
+named by that command; Ovim does not scan the shared temp directory.
+The explicit `always_prompt` policy still prompts for every effect.
+
 For trusted work where approval interruptions are more costly than the safety
 gate, click `YOLO OFF` at the top right of the chat to switch it to `YOLO ON`.
 YOLO is opt-in per chat and defaults off. It bypasses Terra and interactive tool

--- a/user-docs/ai.md
+++ b/user-docs/ai.md
@@ -14,11 +14,17 @@ to open the same chat with that code attached to the composer. When a direct
 Codex profile needs credentials, Ovim shows a
 sign-in dialog at the point of use:
 
-1. Press `Enter` to open ChatGPT sign-in in your browser.
+1. Press `Enter` to sign in. In a local terminal, Ovim opens ChatGPT sign-in in
+   your browser. Over SSH, Ovim instead shows a verification URL and one-time
+   device code that you can use in any browser; no port forwarding is needed.
 2. Complete sign-in and return to Ovim; the pending draft or unchanged
    selection resumes automatically.
 3. Press `Esc` instead to dismiss the dialog without losing the draft or
    selection.
+
+Press `D` to choose device-code sign-in explicitly or `B` to choose the local
+browser callback. Device codes expire after 15 minutes. Only enter a code when
+you started the login yourself in Ovim.
 
 Ovim stores its own refreshable credentials as `ovim/codex-auth.json` in the
 platform config directory (`~/.config` on Linux,

--- a/user-docs/headless.md
+++ b/user-docs/headless.md
@@ -73,12 +73,23 @@ ovim send -s dev "  "
 ovim send -s dev "inspect the project<Enter>"
 ```
 
-For unattended use, complete Ovim's contextual Codex sign-in once in the TUI
-before starting the headless session. The credential is stored in the same
-platform config directory and refreshes automatically. If credentials need
-renewal during a headless session, the auth dialog blocks inference without
-consuming the draft; attach a TUI or complete sign-in in a regular Ovim session
-before retrying.
+For unattended use, complete Ovim's contextual Codex sign-in once before
+starting the session. The credential is stored in the same platform config
+directory and refreshes automatically. If credentials need renewal during a
+headless session, the auth dialog blocks inference without consuming the
+draft. Device-code sign-in can be completed entirely through the headless API:
+
+```bash
+ovim send -s dev D
+ovim snapshot -s dev --format json
+```
+
+Wait for `ai_chat.codex_auth.phase` to become `waiting_for_device_code`, then
+open its `verification_url` in any browser and enter its `user_code`. Ovim
+continues automatically after approval. Device-code login must be enabled in
+your ChatGPT security settings or by your workspace administrator. You can
+send `B` instead to use the localhost browser callback, or `<Esc>` to cancel
+without losing the draft.
 
 If auto mode pauses an Ovim tool for approval, the agent round remains blocked
 until the decision arrives. Inspect it with `ovim snapshot -s dev`, then

--- a/user-docs/troubleshooting.md
+++ b/user-docs/troubleshooting.md
@@ -44,6 +44,14 @@ Ovim signs in to ChatGPT independently from Codex CLI. Open AI chat with
 browser flow. A visual selection attached with `Space Space` uses the same chat
 and sign-in flow.
 
+In an SSH session, `Enter` uses device-code sign-in instead: open the URL shown
+by Ovim on your local computer and enter the one-time code. The remote machine
+does not need a browser and you do not need to forward Ovim's localhost OAuth
+port. Press `D` to select this flow explicitly, or `B` to use the localhost
+browser callback when you have already arranged access to it. If an
+organization disables device-code authorization, Ovim reports that policy and
+keeps browser sign-in available.
+
 Ovim refreshes expiring credentials automatically and retries one inference
 request after an unexpected `401 Unauthorized`. If the refresh token is
 rejected, the dialog asks you to sign in again while preserving the current


### PR DESCRIPTION
## Summary

- use OpenAI device-code authorization by default when Ovim detects an SSH session
- keep the localhost browser callback for local terminals and expose D/B method overrides
- show the verification URL, one-time code, expiry, and phishing warning in the TUI
- expose structured Codex auth state in headless snapshots
- preserve Ovim-owned credential isolation and abort pending auth work on cancellation
- document SSH and headless sign-in behavior

## Verification

- live headless session with SSH_CONNECTION and isolated config reached waiting_for_device_code against auth.openai.com
- snapshot reported the official verification URL and a nonempty 10-character code; code was redacted from logs
- Esc removed auth state, preserved the draft, and wrote no credential file
- 1,573 ovim-core library tests passed with TMPDIR outside the unrelated /tmp/.git on this host
- 255 ovim library tests passed; 2 network/install tests ignored
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
