### PR TITLE
feat(remote): edit a project hosted by another ovim process

### DIFF
--- a/ovim-core/src/native_diff.rs
+++ b/ovim-core/src/native_diff.rs
@@ -2,14 +2,14 @@
 
 use anyhow::{bail, Context, Result};
 use git2::{Delta, Diff, DiffFindOptions, DiffOptions, Oid, Patch, Repository, Tree};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const MAX_PATCH_BYTES: usize = 4 * 1024 * 1024;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffReview {
     pub root: PathBuf,
@@ -18,7 +18,7 @@ pub struct DiffReview {
     pub files: Vec<DiffFile>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffFile {
     pub path: String,

--- a/ovim/Cargo.toml
+++ b/ovim/Cargo.toml
@@ -37,7 +37,7 @@ base64 = "0.22"
 clap = { version = "4.4", features = ["derive"] }
 lsp-types = "0.97"
 mlua = { version = "0.9", features = ["lua54", "vendored", "async", "serialize"], optional = true }
-reqwest = { version = "0.12.23", features = ["json", "blocking"] }
+reqwest = { version = "0.12.23", features = ["json", "blocking", "stream"] }
 rand = "0.8"
 dirs = "5.0"
 prometheus = { version = "0.13", optional = true }

--- a/ovim/src/api/gui.rs
+++ b/ovim/src/api/gui.rs
@@ -12,7 +12,7 @@
 use crate::gui::server::GuiChannel;
 use crate::gui::{GuiCommand, GuiSnapshot, SNAPSHOT_EVENT};
 use axum::{
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::StatusCode,
     response::{
         sse::{Event, KeepAlive, Sse},
@@ -33,9 +33,23 @@ use tokio::sync::watch;
 /// would only discover it on the next edit.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
 
+/// The largest command body this route will buffer.
+///
+/// Axum's 2 MiB default is smaller than what the conversation legitimately
+/// carries. `native_diff` hands back patches of up to 4 MiB and the frontend
+/// posts one straight back as [`GuiCommand::OpenDiffBuffer`]; `AttachImageData`
+/// spells image bytes as a JSON array of numbers, which costs several bytes
+/// per byte. In-process those commands meet no limit at all, so keeping the
+/// default here would make a remote frontend fail where a local one succeeds,
+/// and with a `413` that names nothing the user can act on.
+const MAX_COMMAND_BODY: usize = 16 * 1024 * 1024;
+
 pub(super) fn router(gui: GuiChannel) -> Router {
     Router::new()
-        .route("/gui/command", post(gui_command))
+        .route(
+            "/gui/command",
+            post(gui_command).layer(DefaultBodyLimit::max(MAX_COMMAND_BODY)),
+        )
         .route("/gui/stream", get(gui_stream))
         .with_state(gui)
 }
@@ -87,8 +101,11 @@ fn snapshot_stream(
                 // The current value is taken as-is the first time round and
                 // waited for afterwards.
                 if !std::mem::take(&mut offer_current) && updates.changed().await.is_err() {
-                    // The editor is gone; ending the stream closes the
-                    // connection, which is how the client learns.
+                    // Only reachable once every `GuiChannel` is gone, which
+                    // cannot happen while this router is still serving: the
+                    // handler's state holds one. A session that stops takes
+                    // its process with it, so what the client learns from is
+                    // the closed socket rather than this arm.
                     return None;
                 }
                 let frame = updates.borrow_and_update().clone();
@@ -274,6 +291,63 @@ mod tests {
 
         assert_eq!(response.unwrap().status(), StatusCode::NO_CONTENT);
         assert!(!keep_running, "shutdown should stop the session");
+    }
+
+    #[tokio::test]
+    async fn a_command_body_larger_than_the_default_limit_still_reaches_the_editor() {
+        // A patch may be up to 4 MiB and the frontend posts it straight back
+        // as an `OpenDiffBuffer`, so Axum's 2 MiB default would fail the
+        // remote path where the in-process one has no limit at all -- and
+        // with a 413 that reads as a broken link.
+        let (app, capability, mut server) = secured_app();
+        let mut editor = Editor::with_content("fn main() {}\n");
+        let command = GuiCommand::OpenDiffBuffer {
+            title: "Diff · big.rs".to_string(),
+            content: "+line\n".repeat(600_000),
+        };
+        assert!(
+            serde_json::to_vec(&command).unwrap().len() > 2 * 1024 * 1024,
+            "the body has to exceed the default limit to prove anything"
+        );
+
+        let (response, _) = tokio::join!(
+            app.oneshot(command_request(&capability, &command)),
+            serve_one(&mut server, &mut editor)
+        );
+
+        assert_eq!(response.unwrap().status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn the_gui_conversation_is_absent_from_the_deprecated_unversioned_paths() {
+        // The GUI pair is a new surface, so it is published only under `/v1`.
+        // The requests are fully authorized: a 404 here has to mean there is
+        // no such route, not that the guard turned it away.
+        let (app, capability, _server) = secured_app();
+
+        for (method, path) in [("POST", "/gui/command"), ("GET", "/gui/stream")] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .header("host", format!("127.0.0.1:{PORT}"))
+                        .header(
+                            "authorization",
+                            format!("Bearer {}", capability.expose_secret()),
+                        )
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::to_vec(&GuiCommand::SelectTab { index: 0 }).unwrap(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+        }
     }
 
     #[tokio::test]

--- a/ovim/src/api/gui.rs
+++ b/ovim/src/api/gui.rs
@@ -1,0 +1,447 @@
+//! The GUI editor conversation, carried over the session API.
+//!
+//! `POST /v1/gui/command` takes one [`GuiCommand`] and answers with the
+//! [`GuiReply`](crate::gui::GuiReply) that command's reply kind promises;
+//! `GET /v1/gui/stream` is a Server-Sent Events feed of
+//! [`GuiSnapshot`]s. Together they are the whole editor conversation, which is
+//! what lets a frontend on another host drive a session over an SSH tunnel.
+//!
+//! Both routes are mounted inside the router that [`super::security`] wraps, so
+//! they carry the same bearer capability and Host guard as every other route.
+
+use crate::gui::server::GuiChannel;
+use crate::gui::{GuiCommand, GuiSnapshot};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Json, Response,
+    },
+    routing::{get, post},
+    Json as JsonExtractor, Router,
+};
+use futures::stream::Stream;
+use std::convert::Infallible;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// How often an idle stream emits a keep-alive comment.
+///
+/// A session can sit untouched for minutes. Without traffic, an SSH tunnel or
+/// any other intermediary is free to reap the connection, and the frontend
+/// would only discover it on the next edit.
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// The name every snapshot frame is published under, so a client can register
+/// one listener rather than parsing untyped messages.
+const SNAPSHOT_EVENT: &str = "snapshot";
+
+pub(super) fn router(gui: GuiChannel) -> Router {
+    Router::new()
+        .route("/gui/command", post(gui_command))
+        .route("/gui/stream", get(gui_stream))
+        .with_state(gui)
+}
+
+/// Handler for POST /v1/gui/command.
+///
+/// A command that failed *in the editor* still answers 200 with a reply
+/// carrying the error, exactly as the in-process transport does; the status
+/// codes here describe the conversation, not the command.
+async fn gui_command(
+    State(gui): State<GuiChannel>,
+    JsonExtractor(command): JsonExtractor<GuiCommand>,
+) -> Response {
+    match gui.send(command).await {
+        Ok(Some(reply)) => Json(reply).into_response(),
+        // A fire-and-forget command is answered as soon as the editor has been
+        // handed it. There is no reply to wait for, so waiting would hang.
+        Ok(None) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": error })),
+        )
+            .into_response(),
+    }
+}
+
+/// Handler for GET /v1/gui/stream.
+async fn gui_stream(
+    State(gui): State<GuiChannel>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    Sse::new(snapshot_stream(gui.subscribe()))
+        .keep_alive(KeepAlive::new().interval(KEEP_ALIVE_INTERVAL))
+}
+
+/// Turn the coalescing update channel into a stream of snapshot events.
+///
+/// The subscription's current value is offered first, so a client joining a
+/// session that is already being watched gets a frame immediately instead of
+/// waiting for the next edit. When there is no current value -- the session was
+/// not projecting anything until this subscriber arrived -- the publisher sees
+/// the new receiver on its next tick and the first frame follows from there.
+fn snapshot_stream(
+    updates: watch::Receiver<Option<GuiSnapshot>>,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    futures::stream::unfold(
+        (updates, true),
+        |(mut updates, mut offer_current)| async move {
+            loop {
+                // The current value is taken as-is the first time round and
+                // waited for afterwards.
+                if !std::mem::take(&mut offer_current) && updates.changed().await.is_err() {
+                    // The editor is gone; ending the stream closes the
+                    // connection, which is how the client learns.
+                    return None;
+                }
+                let frame = updates.borrow_and_update().clone();
+                // An empty channel carries no frame: it starts out empty and is
+                // cleared again when the last subscriber leaves.
+                if let Some(snapshot) = frame {
+                    return Some((snapshot_event(&snapshot), (updates, offer_current)));
+                }
+            }
+        },
+    )
+}
+
+fn snapshot_event(snapshot: &GuiSnapshot) -> Result<Event, Infallible> {
+    // A snapshot is plain data with no map keys and no non-finite floats, so
+    // serialization cannot fail. A comment frame is a harmless last resort,
+    // which is better than panicking on a live connection.
+    Ok(Event::default()
+        .event(SNAPSHOT_EVENT)
+        .json_data(snapshot)
+        .unwrap_or_else(|_| Event::default().comment("snapshot could not be serialized")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::state::ApiState;
+    use crate::api::{routes::create_router, security};
+    use crate::editor::Editor;
+    use crate::gui::server::{gui_channel, GuiServer};
+    use crate::gui::GuiReply;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+        Router,
+    };
+    use futures::StreamExt;
+    use ovim_core::session::SessionCapability;
+    use tokio::sync::mpsc;
+    use tower::ServiceExt;
+
+    const PORT: u16 = 4242;
+
+    /// The real router behind the real security layer, plus the editor end of
+    /// the conversation for the test to drive.
+    ///
+    /// The editor is never spawned onto another task: it embeds a Lua state and
+    /// so is deliberately not `Send`, which is also why the real session drives
+    /// it from its own event loop rather than from the server's tasks.
+    fn secured_app() -> (Router, String, GuiServer) {
+        let capability = SessionCapability::generate();
+        let secret = capability.expose_secret().to_string();
+        let (channel, server) = gui_channel((80, 24));
+        let (tx, _rx) = mpsc::channel(8);
+        let app = security::secure_router(
+            create_router(ApiState::new(tx), channel),
+            security::ApiSecurity::new(capability, PORT),
+        );
+        (app, secret, server)
+    }
+
+    fn command_request(secret: &str, command: &GuiCommand) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/gui/command")
+            .header("host", format!("127.0.0.1:{PORT}"))
+            .header("authorization", format!("Bearer {secret}"))
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(command).unwrap()))
+            .unwrap()
+    }
+
+    fn stream_request(secret: &str) -> Request<Body> {
+        Request::builder()
+            .uri("/v1/gui/stream")
+            .header("host", format!("127.0.0.1:{PORT}"))
+            .header("authorization", format!("Bearer {secret}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    /// Answer one command the way `run_headless_loop` does, reporting whether
+    /// the session should keep running.
+    async fn serve_one(server: &mut GuiServer, editor: &mut Editor) -> bool {
+        let request = server.recv().await.expect("a command should arrive");
+        let keep_running = server.handle(request, editor).await;
+        server.publish(editor);
+        keep_running
+    }
+
+    /// Split one Server-Sent Events frame into its event name and its data.
+    fn parse_event(frame: &str) -> (Option<String>, String) {
+        let mut name = None;
+        let mut data = String::new();
+        for line in frame.lines() {
+            if let Some(value) = line.strip_prefix("event:") {
+                name = Some(value.trim_start().to_string());
+            } else if let Some(value) = line.strip_prefix("data:") {
+                data.push_str(value.trim_start());
+            }
+        }
+        (name, data)
+    }
+
+    #[tokio::test]
+    async fn a_command_posted_over_the_api_comes_back_as_the_reply_it_declared() {
+        let (app, secret, mut server) = secured_app();
+        let mut editor = Editor::with_content("fn main() {}\n");
+        let command = GuiCommand::EditorCommand {
+            command: "set number".to_string(),
+        };
+
+        let (response, keep_running) = tokio::join!(
+            app.oneshot(command_request(&secret, &command)),
+            serve_one(&mut server, &mut editor)
+        );
+
+        assert!(keep_running);
+        let response = response.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+        let reply: GuiReply = serde_json::from_slice(&body).unwrap();
+        assert_eq!(reply, GuiReply::Unit(Ok(())));
+        // The command reached the real editor rather than being acknowledged
+        // by the route.
+        assert!(editor.options.number);
+    }
+
+    #[tokio::test]
+    async fn every_route_answer_carries_the_shape_its_command_declared() {
+        // The command fixes the reply shape at both ends. A route that guessed
+        // instead would still return valid JSON, so the only thing that catches
+        // it is comparing what came back against `reply_kind`.
+        let (app, secret, mut server) = secured_app();
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        for command in [
+            GuiCommand::Snapshot {
+                columns: 100,
+                rows: 30,
+            },
+            // The last three answer `Err` -- no vector document, no worktree --
+            // but the shape is what is being pinned here, not the outcome.
+            GuiCommand::VectorSource,
+            GuiCommand::DiffReview { spec: None },
+            GuiCommand::DiffFilePatch {
+                spec: None,
+                path: "src/main.rs".to_string(),
+            },
+            GuiCommand::SelectTab { index: 0 },
+        ] {
+            let (response, _) = tokio::join!(
+                app.clone().oneshot(command_request(&secret, &command)),
+                serve_one(&mut server, &mut editor)
+            );
+
+            let response = response.unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{command:?}");
+            let body = to_bytes(response.into_body(), 8 * 1024 * 1024)
+                .await
+                .unwrap();
+            let reply: GuiReply = serde_json::from_slice(&body).unwrap();
+            assert_eq!(reply.kind(), command.reply_kind(), "{command:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_fire_and_forget_command_is_answered_without_waiting_for_a_reply() {
+        // `Shutdown` never answers, so a route that waited for one would hang
+        // the request until the session died.
+        let (app, secret, mut server) = secured_app();
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        let (response, keep_running) = tokio::join!(
+            app.oneshot(command_request(&secret, &GuiCommand::Shutdown)),
+            serve_one(&mut server, &mut editor)
+        );
+
+        assert_eq!(response.unwrap().status(), StatusCode::NO_CONTENT);
+        assert!(!keep_running, "shutdown should stop the session");
+    }
+
+    #[tokio::test]
+    async fn an_unauthenticated_command_never_reaches_the_editor() {
+        let (app, _secret, mut server) = secured_app();
+
+        // The app is cloned so the router -- and with it the sending end of the
+        // conversation -- outlives the request; otherwise `recv` would return
+        // on a closed channel rather than on a dispatched command.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/gui/command")
+                    .header("host", format!("127.0.0.1:{PORT}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&GuiCommand::Shutdown).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), server.recv())
+                .await
+                .is_err(),
+            "a rejected command must not be dispatched"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unauthenticated_stream_is_refused_before_a_subscription_exists() {
+        let (app, _secret, mut server) = secured_app();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/gui/stream")
+                    .header("host", format!("127.0.0.1:{PORT}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        // A rejected request must not have started the session projecting.
+        server.publish(&Editor::with_content("fn main() {}\n"));
+        assert_eq!(server.frames_built(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_subscriber_receives_a_snapshot_that_an_unwatched_session_never_builds() {
+        let (app, secret, mut server) = secured_app();
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        // Nothing is streaming yet, so ticking the publisher costs nothing.
+        editor.set_status_message("saved".to_string());
+        editor.mark_dirty();
+        server.publish(&editor);
+        assert_eq!(server.frames_built(), 0);
+
+        let response = app.oneshot(stream_request(&secret)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+
+        // The subscription exists from the moment the handler ran, so the very
+        // next publish projects a frame for it even though the editor has not
+        // changed since.
+        server.publish(&editor);
+        assert_eq!(server.frames_built(), 1);
+
+        let mut body = response.into_body().into_data_stream();
+        let chunk = tokio::time::timeout(Duration::from_secs(5), body.next())
+            .await
+            .expect("the first frame should arrive promptly")
+            .expect("the stream should not end")
+            .unwrap();
+
+        let frame = String::from_utf8(chunk.to_vec()).unwrap();
+        let (name, payload) = parse_event(&frame);
+        assert_eq!(name.as_deref(), Some(SNAPSHOT_EVENT));
+        let snapshot: GuiSnapshot = serde_json::from_str(&payload).unwrap();
+        assert_eq!(snapshot.status_message, "saved");
+    }
+
+    /// A repository with one committed file and one uncommitted line added.
+    fn repository_with_one_change() -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(directory.path()).unwrap();
+        let repository = git2::Repository::init(&root).unwrap();
+        std::fs::write(root.join("a.txt"), "one\ntwo\n").unwrap();
+
+        let mut index = repository.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree = repository.find_tree(index.write_tree().unwrap()).unwrap();
+        let signature = git2::Signature::now("Ovim", "ovim@example.invalid").unwrap();
+        repository
+            .commit(Some("HEAD"), &signature, &signature, "first", &tree, &[])
+            .unwrap();
+
+        std::fs::write(root.join("a.txt"), "one\ntwo\nthree\n").unwrap();
+        (directory, root)
+    }
+
+    #[tokio::test]
+    async fn the_diff_commands_compute_against_the_workspace_the_editor_is_in() {
+        // This is the whole point of moving the diff server-side: the answer
+        // describes the repository the editor is sitting in, and the caller
+        // never needs to be able to reach it.
+        let (_directory, root) = repository_with_one_change();
+        let (app, secret, mut server) = secured_app();
+        let mut editor = Editor::with_content("");
+        editor.set_workspace_root(&root).unwrap();
+
+        let (response, _) = tokio::join!(
+            app.clone().oneshot(command_request(
+                &secret,
+                &GuiCommand::DiffReview { spec: None }
+            )),
+            serve_one(&mut server, &mut editor)
+        );
+        let body = to_bytes(response.unwrap().into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let GuiReply::DiffReview(review) = serde_json::from_slice(&body).unwrap() else {
+            panic!("a DiffReview command must answer with a review");
+        };
+        let review = review.expect("the workspace is a Git worktree");
+        assert_eq!(review.root, root);
+        assert_eq!(
+            review
+                .files
+                .iter()
+                .map(|file| file.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.txt"]
+        );
+
+        let (response, _) = tokio::join!(
+            app.oneshot(command_request(
+                &secret,
+                &GuiCommand::DiffFilePatch {
+                    spec: None,
+                    path: "a.txt".to_string(),
+                },
+            )),
+            serve_one(&mut server, &mut editor)
+        );
+        let body = to_bytes(response.unwrap().into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let GuiReply::DiffPatch(patch) = serde_json::from_slice(&body).unwrap() else {
+            panic!("a DiffFilePatch command must answer with a patch");
+        };
+        let patch = patch.expect("a.txt is changed in the worktree");
+        assert!(patch.contains("+three"), "{patch}");
+    }
+}

--- a/ovim/src/api/gui.rs
+++ b/ovim/src/api/gui.rs
@@ -10,7 +10,7 @@
 //! they carry the same bearer capability and Host guard as every other route.
 
 use crate::gui::server::GuiChannel;
-use crate::gui::{GuiCommand, GuiSnapshot};
+use crate::gui::{GuiCommand, GuiSnapshot, SNAPSHOT_EVENT};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -32,10 +32,6 @@ use tokio::sync::watch;
 /// any other intermediary is free to reap the connection, and the frontend
 /// would only discover it on the next edit.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
-
-/// The name every snapshot frame is published under, so a client can register
-/// one listener rather than parsing untyped messages.
-const SNAPSHOT_EVENT: &str = "snapshot";
 
 pub(super) fn router(gui: GuiChannel) -> Router {
     Router::new()
@@ -142,34 +138,39 @@ mod tests {
     /// The editor is never spawned onto another task: it embeds a Lua state and
     /// so is deliberately not `Send`, which is also why the real session drives
     /// it from its own event loop rather than from the server's tasks.
-    fn secured_app() -> (Router, String, GuiServer) {
+    fn secured_app() -> (Router, SessionCapability, GuiServer) {
         let capability = SessionCapability::generate();
-        let secret = capability.expose_secret().to_string();
         let (channel, server) = gui_channel((80, 24));
         let (tx, _rx) = mpsc::channel(8);
         let app = security::secure_router(
             create_router(ApiState::new(tx), channel),
-            security::ApiSecurity::new(capability, PORT),
+            security::ApiSecurity::new(capability.clone(), PORT),
         );
-        (app, secret, server)
+        (app, capability, server)
     }
 
-    fn command_request(secret: &str, command: &GuiCommand) -> Request<Body> {
+    fn command_request(capability: &SessionCapability, command: &GuiCommand) -> Request<Body> {
         Request::builder()
             .method("POST")
             .uri("/v1/gui/command")
             .header("host", format!("127.0.0.1:{PORT}"))
-            .header("authorization", format!("Bearer {secret}"))
+            .header(
+                "authorization",
+                format!("Bearer {}", capability.expose_secret()),
+            )
             .header("content-type", "application/json")
             .body(Body::from(serde_json::to_vec(command).unwrap()))
             .unwrap()
     }
 
-    fn stream_request(secret: &str) -> Request<Body> {
+    fn stream_request(capability: &SessionCapability) -> Request<Body> {
         Request::builder()
             .uri("/v1/gui/stream")
             .header("host", format!("127.0.0.1:{PORT}"))
-            .header("authorization", format!("Bearer {secret}"))
+            .header(
+                "authorization",
+                format!("Bearer {}", capability.expose_secret()),
+            )
             .body(Body::empty())
             .unwrap()
     }
@@ -199,14 +200,14 @@ mod tests {
 
     #[tokio::test]
     async fn a_command_posted_over_the_api_comes_back_as_the_reply_it_declared() {
-        let (app, secret, mut server) = secured_app();
+        let (app, capability, mut server) = secured_app();
         let mut editor = Editor::with_content("fn main() {}\n");
         let command = GuiCommand::EditorCommand {
             command: "set number".to_string(),
         };
 
         let (response, keep_running) = tokio::join!(
-            app.oneshot(command_request(&secret, &command)),
+            app.oneshot(command_request(&capability, &command)),
             serve_one(&mut server, &mut editor)
         );
 
@@ -226,7 +227,7 @@ mod tests {
         // The command fixes the reply shape at both ends. A route that guessed
         // instead would still return valid JSON, so the only thing that catches
         // it is comparing what came back against `reply_kind`.
-        let (app, secret, mut server) = secured_app();
+        let (app, capability, mut server) = secured_app();
         let mut editor = Editor::with_content("fn main() {}\n");
 
         for command in [
@@ -245,7 +246,7 @@ mod tests {
             GuiCommand::SelectTab { index: 0 },
         ] {
             let (response, _) = tokio::join!(
-                app.clone().oneshot(command_request(&secret, &command)),
+                app.clone().oneshot(command_request(&capability, &command)),
                 serve_one(&mut server, &mut editor)
             );
 
@@ -263,11 +264,11 @@ mod tests {
     async fn a_fire_and_forget_command_is_answered_without_waiting_for_a_reply() {
         // `Shutdown` never answers, so a route that waited for one would hang
         // the request until the session died.
-        let (app, secret, mut server) = secured_app();
+        let (app, capability, mut server) = secured_app();
         let mut editor = Editor::with_content("fn main() {}\n");
 
         let (response, keep_running) = tokio::join!(
-            app.oneshot(command_request(&secret, &GuiCommand::Shutdown)),
+            app.oneshot(command_request(&capability, &GuiCommand::Shutdown)),
             serve_one(&mut server, &mut editor)
         );
 
@@ -277,7 +278,7 @@ mod tests {
 
     #[tokio::test]
     async fn an_unauthenticated_command_never_reaches_the_editor() {
-        let (app, _secret, mut server) = secured_app();
+        let (app, _capability, mut server) = secured_app();
 
         // The app is cloned so the router -- and with it the sending end of the
         // conversation -- outlives the request; otherwise `recv` would return
@@ -309,7 +310,7 @@ mod tests {
 
     #[tokio::test]
     async fn an_unauthenticated_stream_is_refused_before_a_subscription_exists() {
-        let (app, _secret, mut server) = secured_app();
+        let (app, _capability, mut server) = secured_app();
 
         let response = app
             .oneshot(
@@ -330,7 +331,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_subscriber_receives_a_snapshot_that_an_unwatched_session_never_builds() {
-        let (app, secret, mut server) = secured_app();
+        let (app, capability, mut server) = secured_app();
         let mut editor = Editor::with_content("fn main() {}\n");
 
         // Nothing is streaming yet, so ticking the publisher costs nothing.
@@ -339,7 +340,7 @@ mod tests {
         server.publish(&editor);
         assert_eq!(server.frames_built(), 0);
 
-        let response = app.oneshot(stream_request(&secret)).await.unwrap();
+        let response = app.oneshot(stream_request(&capability)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response
@@ -397,13 +398,13 @@ mod tests {
         // describes the repository the editor is sitting in, and the caller
         // never needs to be able to reach it.
         let (_directory, root) = repository_with_one_change();
-        let (app, secret, mut server) = secured_app();
+        let (app, capability, mut server) = secured_app();
         let mut editor = Editor::with_content("");
         editor.set_workspace_root(&root).unwrap();
 
         let (response, _) = tokio::join!(
             app.clone().oneshot(command_request(
-                &secret,
+                &capability,
                 &GuiCommand::DiffReview { spec: None }
             )),
             serve_one(&mut server, &mut editor)
@@ -427,7 +428,7 @@ mod tests {
 
         let (response, _) = tokio::join!(
             app.oneshot(command_request(
-                &secret,
+                &capability,
                 &GuiCommand::DiffFilePatch {
                     spec: None,
                     path: "a.txt".to_string(),
@@ -443,5 +444,85 @@ mod tests {
         };
         let patch = patch.expect("a.txt is changed in the worktree");
         assert!(patch.contains("+three"), "{patch}");
+    }
+
+    /// Serve a router on a loopback port and report where to reach it.
+    async fn serve(app: Router) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        address
+    }
+
+    #[tokio::test]
+    async fn a_remote_transport_drives_a_real_session_over_a_socket() {
+        // The whole conversation end to end: the real routes behind the real
+        // security layer, over a real socket, driving a real editor -- and
+        // dialled on a port that is not the one the session claims to listen
+        // on, which is the shape an SSH tunnel produces.
+        let (app, capability, mut server) = secured_app();
+        let mut editor = Editor::with_content(
+            "fn main() {}
+",
+        );
+        let address = serve(app).await;
+        assert_ne!(
+            address.port(),
+            PORT,
+            "the ports must differ to prove anything"
+        );
+
+        let transport = crate::gui::RemoteTransport::open(crate::gui::RemoteEndpoint::new(
+            address.to_string(),
+            PORT,
+            capability,
+        ))
+        .await
+        .expect("the session should accept the transport");
+        let bridge = crate::gui::GuiBridge::new(std::sync::Arc::new(transport));
+        let mut updates = bridge.subscribe();
+
+        // The editor is driven from this task rather than spawned: it embeds a
+        // Lua state and so is deliberately not `Send`.
+        let (result, _) = tokio::join!(
+            bridge.editor_command("set number".to_string()),
+            serve_one(&mut server, &mut editor)
+        );
+        result.expect("the command should have been carried out");
+        assert!(editor.options.number, "the command reached the real editor");
+
+        // Publishing happens on the session's tick; the subscription exists
+        // from the moment the stream handler ran, so the frame that follows
+        // the command travels the SSE feed to this subscriber.
+        tokio::time::timeout(Duration::from_secs(5), updates.changed())
+            .await
+            .expect("a frame should arrive over the stream")
+            .unwrap();
+        let first = updates.borrow_and_update().clone().unwrap();
+        let text: String = first.lines[0]
+            .segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect();
+        assert_eq!(text, "fn main() {}");
+
+        let (result, _) = tokio::join!(
+            bridge.paste("edited".to_string()),
+            serve_one(&mut server, &mut editor)
+        );
+        result.expect("the paste should have been carried out");
+        tokio::time::timeout(Duration::from_secs(5), updates.changed())
+            .await
+            .expect("an edit should produce another frame")
+            .unwrap();
+        let second = updates.borrow_and_update().clone().unwrap();
+        assert!(
+            second.revision > first.revision,
+            "{} should follow {}",
+            second.revision,
+            first.revision
+        );
     }
 }

--- a/ovim/src/api/mod.rs
+++ b/ovim/src/api/mod.rs
@@ -3,7 +3,9 @@ mod handlers;
 pub mod mcp;
 mod mcp_handler;
 mod routes;
-mod security;
+// `pub(crate)` so the GUI transport tests can put a stub session behind the
+// real Host and capability guard rather than an imitation of it.
+pub(crate) mod security;
 mod state;
 
 pub use mcp::{get_resources, get_tools, JsonRpcRequest, JsonRpcResponse};

--- a/ovim/src/api/mod.rs
+++ b/ovim/src/api/mod.rs
@@ -1,3 +1,4 @@
+mod gui;
 mod handlers;
 pub mod mcp;
 mod mcp_handler;
@@ -19,6 +20,7 @@ pub use state::{
     VisualSelection, AGENT_API_SCHEMA_VERSION, SNAPSHOT_SCHEMA_VERSION,
 };
 
+use crate::gui::server::GuiChannel;
 use anyhow::Result;
 use axum::{
     http::Request,
@@ -67,6 +69,7 @@ pub async fn start_server(
     tx: mpsc::Sender<ApiRequest>,
     port_tx: tokio::sync::oneshot::Sender<u16>,
     capability: SessionCapability,
+    gui: GuiChannel,
 ) -> Result<()> {
     anyhow::ensure!(
         capability.is_configured(),
@@ -81,7 +84,7 @@ pub async fn start_server(
     let security = security::ApiSecurity::new(capability, actual_addr.port());
     let state = ApiState::new(tx);
     let app = security::secure_router(
-        create_router(state).layer(middleware::from_fn(deprecation_middleware)),
+        create_router(state, gui).layer(middleware::from_fn(deprecation_middleware)),
         security,
     );
 

--- a/ovim/src/api/routes.rs
+++ b/ovim/src/api/routes.rs
@@ -7,13 +7,14 @@ use super::handlers::{
 };
 use super::mcp_handler::handle_mcp;
 use super::state::ApiState;
+use crate::gui::server::GuiChannel;
 use axum::{
     routing::{get, post, put},
     Router,
 };
 
 /// Create the API router with all routes
-pub(crate) fn create_router(state: ApiState) -> Router {
+pub(crate) fn create_router(state: ApiState, gui: GuiChannel) -> Router {
     // V1 API routes (current stable API)
     let v1_routes = Router::new()
         .route("/health", get(get_health))
@@ -51,16 +52,18 @@ pub(crate) fn create_router(state: ApiState) -> Router {
         .route("/insert", post(insert_lines))
         .route("/delete-lines", post(delete_lines))
         .route("/lines", get(read_lines))
-        .route("/mcp", post(handle_mcp));
+        .route("/mcp", post(handle_mcp))
+        .with_state(state);
 
     // Root router with version namespaces
     Router::new()
-        // V1 API under /v1 prefix (recommended)
-        .nest("/v1", v1_routes.clone())
+        // V1 API under /v1 prefix (recommended). The GUI conversation is a new
+        // surface, so it is published only here and never on the deprecated
+        // unversioned paths below.
+        .nest("/v1", v1_routes.clone().merge(super::gui::router(gui)))
         // Legacy routes (no prefix) - for backward compatibility
         // These will be removed in ovim v1.0
         .merge(v1_routes)
-        .with_state(state)
 }
 
 #[cfg(test)]
@@ -77,6 +80,12 @@ mod tests {
     };
     use tokio::sync::mpsc;
     use tower::ServiceExt;
+
+    /// The router as `start_server` builds it, with the editor end of the GUI
+    /// conversation discarded because these tests exercise the API routes.
+    fn router(state: ApiState) -> Router {
+        create_router(state, crate::gui::server::gui_channel((120, 35)).0)
+    }
 
     #[tokio::test]
     async fn versioned_agent_list_route_preserves_snapshot_schema() {
@@ -102,7 +111,7 @@ mod tests {
             }))
             .unwrap();
         });
-        let response = create_router(ApiState::new(tx))
+        let response = router(ApiState::new(tx))
             .oneshot(
                 Request::builder()
                     .uri(format!("/v1/agents?run_id={run_id}"))
@@ -148,7 +157,7 @@ mod tests {
             }))
             .unwrap();
         });
-        let response = create_router(ApiState::new(tx))
+        let response = router(ApiState::new(tx))
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -173,7 +182,7 @@ mod tests {
     #[tokio::test]
     async fn malformed_and_stale_agent_controls_fail_with_distinct_statuses() {
         let (tx, _rx) = mpsc::channel(1);
-        let invalid = create_router(ApiState::new(tx))
+        let invalid = router(ApiState::new(tx))
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -204,7 +213,7 @@ mod tests {
             }))
             .unwrap();
         });
-        let stale = create_router(ApiState::new(tx))
+        let stale = router(ApiState::new(tx))
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -263,7 +272,7 @@ mod tests {
             }))
             .unwrap();
         });
-        let response = create_router(ApiState::new(tx))
+        let response = router(ApiState::new(tx))
             .oneshot(
                 Request::builder()
                     .method("POST")

--- a/ovim/src/api/security.rs
+++ b/ovim/src/api/security.rs
@@ -10,13 +10,13 @@ use serde_json::json;
 
 /// Security boundary for one loopback automation session.
 #[derive(Clone)]
-pub(super) struct ApiSecurity {
+pub(crate) struct ApiSecurity {
     capability: SessionCapability,
     port: u16,
 }
 
 impl ApiSecurity {
-    pub(super) fn new(capability: SessionCapability, port: u16) -> Self {
+    pub(crate) fn new(capability: SessionCapability, port: u16) -> Self {
         Self { capability, port }
     }
 
@@ -101,7 +101,7 @@ async fn require_session_capability(
     next.run(request).await
 }
 
-pub(super) fn secure_router(router: Router, security: ApiSecurity) -> Router {
+pub(crate) fn secure_router(router: Router, security: ApiSecurity) -> Router {
     router.layer(axum::middleware::from_fn_with_state(
         security,
         require_session_capability,

--- a/ovim/src/bin/ovim-gui/main.rs
+++ b/ovim/src/bin/ovim-gui/main.rs
@@ -1,26 +1,64 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use ovim::cli::FileArg;
+use ovim::gui::RemoteEndpoint;
+use std::path::PathBuf;
+
+/// The value of a flag, written either `--flag value` or `--flag=value`.
+fn flag_value(
+    inline: Option<String>,
+    rest: &mut impl Iterator<Item = String>,
+    flag: &str,
+) -> Result<String> {
+    inline
+        .or_else(|| rest.next())
+        .with_context(|| format!("{flag} needs a value"))
+}
 
 fn main() -> Result<()> {
     let mut file = None;
     let mut resume = false;
-    for argument in std::env::args().skip(1) {
-        if argument == "--resume" {
-            resume = true;
-        } else if argument.starts_with('-') {
-            anyhow::bail!("Unknown GUI option: {argument}");
-        } else if file.is_none() {
-            file = Some(FileArg::parse(&argument));
-        } else {
-            anyhow::bail!("Only one file or directory can be opened at startup");
+    let mut remote_session: Option<PathBuf> = None;
+    let mut remote_endpoint: Option<String> = None;
+    let mut arguments = std::env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        let (flag, inline) = match argument.split_once('=') {
+            Some((flag, value)) => (flag.to_string(), Some(value.to_string())),
+            None => (argument.clone(), None),
+        };
+        match flag.as_str() {
+            "--resume" => resume = true,
+            // The capability travels in the session descriptor rather than in
+            // an argument, so it never reaches the process table.
+            "--remote-session" => {
+                remote_session = Some(PathBuf::from(flag_value(
+                    inline,
+                    &mut arguments,
+                    "--remote-session",
+                )?))
+            }
+            "--remote-endpoint" => {
+                remote_endpoint = Some(flag_value(inline, &mut arguments, "--remote-endpoint")?)
+            }
+            _ if argument.starts_with('-') => anyhow::bail!("Unknown GUI option: {argument}"),
+            _ if file.is_none() => file = Some(FileArg::parse(&argument)),
+            _ => anyhow::bail!("Only one file or directory can be opened at startup"),
         }
     }
+
+    anyhow::ensure!(
+        remote_session.is_some() || remote_endpoint.is_none(),
+        "--remote-endpoint needs --remote-session: without a descriptor there is no capability to \
+         authenticate with"
+    );
+    let remote = remote_session
+        .map(|path| RemoteEndpoint::from_session_file(&path, remote_endpoint.as_deref()))
+        .transpose()?;
 
     let _ = ovim::log::init();
     if let Err(error) = ovim::language_config::LanguageRegistry::init() {
         ovim_core::log_warn!("gui", "Language registry initialization: {}", error);
     }
-    ovim::gui::app::run(file, resume)
+    ovim::gui::app::run(file, resume, remote)
 }

--- a/ovim/src/cli.rs
+++ b/ovim/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(name = "ovim")]
@@ -129,6 +130,25 @@ pub enum Command {
         /// Resume persisted AI conversations instead of starting fresh chats
         #[arg(long)]
         resume: bool,
+
+        /// Drive an editor that is already running elsewhere.
+        ///
+        /// Takes the session descriptor a headless run writes
+        /// (`<cache>/ovim/sessions/<name>.json` on that host), copied to this
+        /// machine. It carries both the capability and the port the session
+        /// listens on, so neither is ever typed on a command line where the
+        /// process table and the shell history would keep it.
+        #[arg(long, value_name = "PATH")]
+        remote_session: Option<PathBuf>,
+
+        /// Where to reach that session: HOST:PORT, or a bare port on loopback.
+        ///
+        /// Defaults to the port in the descriptor, which is right when the
+        /// session is on this machine. Under `ssh -L` this is the local end of
+        /// the tunnel, while the descriptor still fixes the Host header the
+        /// session requires.
+        #[arg(long, value_name = "HOST:PORT", requires = "remote_session")]
+        remote_endpoint: Option<String>,
     },
 
     // ── File Operations ──────────────────────────────────────────────
@@ -631,8 +651,40 @@ mod tests {
             Some(Command::Gui {
                 file: Some(ref file),
                 resume: true,
+                remote_session: None,
+                remote_endpoint: None,
             }) if file == "src/main.rs"
         ));
+    }
+
+    #[test]
+    fn a_remote_gui_takes_its_capability_from_a_descriptor_and_never_from_an_argument() {
+        let cli = Cli::try_parse_from([
+            "ovim",
+            "gui",
+            "--remote-session",
+            "dev.json",
+            "--remote-endpoint",
+            "127.0.0.1:9000",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Gui {
+                remote_session: Some(ref path),
+                remote_endpoint: Some(ref endpoint),
+                ..
+            }) if path == std::path::Path::new("dev.json") && endpoint == "127.0.0.1:9000"
+        ));
+    }
+
+    #[test]
+    fn an_endpoint_without_a_descriptor_is_refused_rather_than_dialled_anonymously() {
+        // Dialling with no capability could only end in a 401, and the flag
+        // pair is the whole of the remote surface, so clap rejects it here.
+        let result = Cli::try_parse_from(["ovim", "gui", "--remote-endpoint", "127.0.0.1:9000"]);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/ovim/src/cli.rs
+++ b/ovim/src/cli.rs
@@ -147,6 +147,11 @@ pub enum Command {
         /// session is on this machine. Under `ssh -L` this is the local end of
         /// the tunnel, while the descriptor still fixes the Host header the
         /// session requires.
+        ///
+        /// The link itself is plain HTTP, so this must name a loopback port or
+        /// the local end of an encrypted tunnel. Pointing it straight at
+        /// another machine would put the capability and the buffer on the
+        /// network in the clear.
         #[arg(long, value_name = "HOST:PORT", requires = "remote_session")]
         remote_endpoint: Option<String>,
     },

--- a/ovim/src/event_loop.rs
+++ b/ovim/src/event_loop.rs
@@ -14,6 +14,7 @@ use ovim::frontend::{
     handle_viewport_resize, process_editor_tick, process_external_file_change,
     process_picker_results, refresh_after_input, FrontendChannels,
 };
+use ovim::gui::server::GuiServer;
 use ovim::session::SessionInfo;
 use ovim::ui::UI;
 
@@ -106,6 +107,7 @@ pub async fn run_headless_loop(
     start_time: SystemTime,
     session_info: Arc<Mutex<SessionInfo>>,
     initial_dimensions: (u16, u16),
+    mut gui: GuiServer,
     mut shutdown_rx: mpsc::Receiver<()>,
 ) -> Result<()> {
     let mut channels = FrontendChannels::new(java_status_rx);
@@ -133,7 +135,21 @@ pub async fn run_headless_loop(
                 if editor.buffer().version() != version_before {
                     last_edit = Instant::now();
                 }
+                // Automation and a watching frontend share one editor, so a
+                // keystroke sent over `/v1/keys` has to reach the stream too.
+                gui.publish(editor);
                 if editor.should_quit() { break; }
+            }
+            Some(request) = gui.recv() => {
+                let version_before = editor.buffer().version();
+                let keep_running = gui.handle(request, editor).await;
+                if editor.buffer().version() != version_before {
+                    last_edit = Instant::now();
+                }
+                // Publish before checking for shutdown so the frontend sees the
+                // result of its own command rather than waiting for the tick.
+                gui.publish(editor);
+                if !keep_running || editor.should_quit() { break; }
             }
             Some((path, cache)) = channels.preview_rx.recv() => {
                 editor.insert_preview(path, cache);
@@ -173,6 +189,9 @@ pub async fn run_headless_loop(
                 {
                     editor.process_pending_rehighlight().await;
                 }
+                // Also the tick on which a newly arrived subscriber is noticed,
+                // so its first frame never waits for the next edit.
+                gui.publish(editor);
             }
         }
     }

--- a/ovim/src/gui/app.rs
+++ b/ovim/src/gui/app.rs
@@ -1,7 +1,9 @@
 //! Tauri application shell shared by `ovim gui` and the `ovim-gui` desktop entry.
 
 use super::browser::BrowserHost;
-use super::{GuiBridge, GuiKeyInput, GuiSnapshot, GuiVectorSource};
+use super::{
+    GuiBridge, GuiKeyInput, GuiSnapshot, GuiVectorSource, RemoteEndpoint, RemoteTransport,
+};
 use crate::cli::FileArg;
 use anyhow::{Context, Result};
 use base64::Engine as _;
@@ -451,7 +453,11 @@ fn gui_open_external(url: String) -> Result<(), String> {
 }
 
 /// Run the native application on the calling thread until its last window closes.
-pub fn run(file: Option<FileArg>, resume: bool) -> Result<()> {
+/// Run the desktop shell, over an editor in this process or in another one.
+///
+/// `remote` swaps the transport under the bridge and nothing else: every Tauri
+/// command below keeps talking to `GuiBridge` and cannot tell the difference.
+pub fn run(file: Option<FileArg>, resume: bool, remote: Option<RemoteEndpoint>) -> Result<()> {
     // Keep Tauri's patchable bundle marker linked even without the updater
     // plugin. The bundler uses it to distinguish deb/AppImage/MSI installs.
     std::hint::black_box(tauri::utils::platform::bundle_type());
@@ -464,8 +470,21 @@ pub fn run(file: Option<FileArg>, resume: bool) -> Result<()> {
     let browser_smoke_client =
         std::env::var_os("OVIM_BROWSER_SMOKE").map(|_| browser_client.clone());
     let services = ovim_core::editor::EditorServices::default().with_browser(browser_client);
-    let bridge = GuiBridge::spawn(file, resume, services)?;
-    let shutdown_bridge = bridge.clone();
+    let (bridge, editor_is_ours) = match remote {
+        Some(endpoint) => (
+            GuiBridge::new(Arc::new(
+                RemoteTransport::connect(endpoint)
+                    .context("Failed to reach the remote Ovim session")?,
+            )),
+            false,
+        ),
+        None => (GuiBridge::spawn(file, resume, services)?, true),
+    };
+    // A remote session deliberately outlives the windows that drive it -- that
+    // is what lets a later run reconnect to warm language servers and undo
+    // history -- so only an editor this process started is this process's to
+    // stop on exit.
+    let shutdown_bridge = editor_is_ours.then(|| bridge.clone());
     let exit_gate = GuiExitGate::default();
     let setup_exit_gate = exit_gate.clone();
     let run_exit_gate = exit_gate.clone();
@@ -587,7 +606,11 @@ pub fn run(file: Option<FileArg>, resume: bool) -> Result<()> {
                 let _ = window.emit("ovim://close-requested", "quit");
             }
         }
-        RunEvent::Exit => shutdown_bridge.shutdown(),
+        RunEvent::Exit => {
+            if let Some(bridge) = &shutdown_bridge {
+                bridge.shutdown();
+            }
+        }
         _ => {}
     });
     Ok(())

--- a/ovim/src/gui/app.rs
+++ b/ovim/src/gui/app.rs
@@ -19,18 +19,18 @@ use tauri::{DragDropEvent, Emitter, EventTarget, Manager, RunEvent, State, Windo
 #[derive(Clone, Default)]
 struct GuiExitGate(Arc<AtomicBool>);
 
+// The diff is computed by whichever host runs the editor, not here. Reading a
+// Git worktree from this process would only work while the editor happens to
+// be local, so both commands are plain passthroughs to the bridge.
 #[tauri::command]
 async fn gui_diff_state(
     bridge: State<'_, GuiBridge>,
     spec: Option<String>,
 ) -> Result<ovim_core::native_diff::DiffReview, String> {
-    let workspace = bridge.diff_workspace().await?;
-    tauri::async_runtime::spawn_blocking(move || {
-        ovim_core::native_diff::review(&workspace, spec.as_deref())
-    })
-    .await
-    .map_err(|error| format!("Diff state task failed: {error}"))?
-    .map_err(|error| format!("Could not read diff: {error:#}"))
+    bridge
+        .diff_review(spec)
+        .await
+        .map_err(|error| format!("Could not read diff: {error}"))
 }
 
 #[tauri::command]
@@ -39,14 +39,10 @@ async fn gui_diff_open_file(
     spec: Option<String>,
     path: String,
 ) -> Result<(), String> {
-    let workspace = bridge.diff_workspace().await?;
-    let selected_path = path.clone();
-    let content = tauri::async_runtime::spawn_blocking(move || {
-        ovim_core::native_diff::file_patch(&workspace, spec.as_deref(), &selected_path)
-    })
-    .await
-    .map_err(|error| format!("Diff file task failed: {error}"))?
-    .map_err(|error| format!("Could not open diff: {error:#}"))?;
+    let content = bridge
+        .diff_file_patch(spec, path.clone())
+        .await
+        .map_err(|error| format!("Could not open diff: {error}"))?;
     bridge
         .open_diff_buffer(format!("Diff · {path}"), content)
         .await

--- a/ovim/src/gui/bridge.rs
+++ b/ovim/src/gui/bridge.rs
@@ -1022,7 +1022,10 @@ impl GuiBridge {
 }
 
 #[cfg(test)]
-mod tests {
+// `pub(crate)` so the remote transport can be driven through the very same
+// sweep as the local one; a helper wired to the wrong command variant has to
+// fail identically over either transport.
+pub(crate) mod tests {
     use super::*;
     use crate::editor::Editor;
     use crate::gui::protocol;
@@ -1271,8 +1274,22 @@ mod tests {
         }
     }
 
+    /// What [`exercise_every_helper`] should put on the wire, in order.
+    ///
+    /// `sample_commands` is the protocol's own list of one value per variant,
+    /// built with the same field values the sweep uses, so deriving the
+    /// expectation from it keeps the two from drifting apart. Its deliberate
+    /// trailing duplicate is dropped here; everything else must appear once.
+    pub(crate) fn every_command_once() -> Vec<GuiCommand> {
+        let mut seen = HashSet::new();
+        protocol::sample_commands()
+            .into_iter()
+            .filter(|command| seen.insert(discriminant(command)))
+            .collect()
+    }
+
     /// Call every typed helper once, with a distinct argument per field.
-    async fn exercise_every_helper(bridge: &GuiBridge) {
+    pub(crate) async fn exercise_every_helper(bridge: &GuiBridge) {
         let key = GuiKeyInput {
             key: "j".to_string(),
             shift: true,
@@ -1385,16 +1402,7 @@ mod tests {
 
         exercise_every_helper(&bridge).await;
 
-        // `sample_commands` is the protocol's own list of one value per
-        // variant, built with the same field values used above, so comparing
-        // against it keeps the sweep and the protocol from drifting apart. Its
-        // deliberate trailing duplicate is dropped here; everything else must
-        // appear once, in order.
-        let mut seen = HashSet::new();
-        let expected: Vec<_> = protocol::sample_commands()
-            .into_iter()
-            .filter(|command| seen.insert(discriminant(command)))
-            .collect();
+        let expected = every_command_once();
         assert_eq!(expected.len(), 32, "the sweep should reach every variant");
         assert_eq!(transport.received(), expected);
     }

--- a/ovim/src/gui/bridge.rs
+++ b/ovim/src/gui/bridge.rs
@@ -12,6 +12,7 @@ use super::protocol::{
 use crate::cli::FileArg;
 use crate::editor::EditorServices;
 use anyhow::{Context, Result};
+use ovim_core::native_diff::DiffReview;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -21,9 +22,9 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, watch};
 
 /// The editor is gone and no command can reach it any more.
-const EDITOR_STOPPED: &str = "The Ovim editor thread has stopped";
+pub(crate) const EDITOR_STOPPED: &str = "The Ovim editor thread has stopped";
 /// The editor took the command but dropped the answer.
-const REPLY_CLOSED: &str = "The Ovim editor thread closed the response";
+pub(crate) const REPLY_CLOSED: &str = "The Ovim editor thread closed the response";
 
 /// One editor request, with the channel its answer travels back on.
 ///
@@ -44,8 +45,14 @@ pub enum GuiRequest {
         feedback: String,
         reply: oneshot::Sender<Result<(), String>>,
     },
-    DiffWorkspace {
-        reply: oneshot::Sender<Result<std::path::PathBuf, String>>,
+    DiffReview {
+        spec: Option<String>,
+        reply: oneshot::Sender<Result<DiffReview, String>>,
+    },
+    DiffFilePatch {
+        spec: Option<String>,
+        path: String,
+        reply: oneshot::Sender<Result<String, String>>,
     },
     OpenDiffBuffer {
         title: String,
@@ -177,7 +184,8 @@ pub enum GuiReplySender {
     Unit(oneshot::Sender<Result<(), String>>),
     Snapshot(oneshot::Sender<Result<GuiSnapshot, String>>),
     VectorSource(oneshot::Sender<Result<GuiVectorSource, String>>),
-    Path(oneshot::Sender<Result<std::path::PathBuf, String>>),
+    DiffReview(oneshot::Sender<Result<DiffReview, String>>),
+    DiffPatch(oneshot::Sender<Result<String, String>>),
 }
 
 impl GuiReplySender {
@@ -204,9 +212,19 @@ impl GuiReplySender {
                     GuiReplyReceiver::VectorSource(rx),
                 )
             }
-            GuiReplyKind::Path => {
+            GuiReplyKind::DiffReview => {
                 let (tx, rx) = oneshot::channel();
-                (GuiReplySender::Path(tx), GuiReplyReceiver::Path(rx))
+                (
+                    GuiReplySender::DiffReview(tx),
+                    GuiReplyReceiver::DiffReview(rx),
+                )
+            }
+            GuiReplyKind::DiffPatch => {
+                let (tx, rx) = oneshot::channel();
+                (
+                    GuiReplySender::DiffPatch(tx),
+                    GuiReplyReceiver::DiffPatch(rx),
+                )
             }
         }
     }
@@ -217,7 +235,8 @@ impl GuiReplySender {
             GuiReplySender::Unit(_) => GuiReplyKind::Unit,
             GuiReplySender::Snapshot(_) => GuiReplyKind::Snapshot,
             GuiReplySender::VectorSource(_) => GuiReplyKind::VectorSource,
-            GuiReplySender::Path(_) => GuiReplyKind::Path,
+            GuiReplySender::DiffReview(_) => GuiReplyKind::DiffReview,
+            GuiReplySender::DiffPatch(_) => GuiReplyKind::DiffPatch,
         }
     }
 }
@@ -228,7 +247,8 @@ pub enum GuiReplyReceiver {
     Unit(oneshot::Receiver<Result<(), String>>),
     Snapshot(oneshot::Receiver<Result<GuiSnapshot, String>>),
     VectorSource(oneshot::Receiver<Result<GuiVectorSource, String>>),
-    Path(oneshot::Receiver<Result<std::path::PathBuf, String>>),
+    DiffReview(oneshot::Receiver<Result<DiffReview, String>>),
+    DiffPatch(oneshot::Receiver<Result<String, String>>),
 }
 
 impl GuiReplyReceiver {
@@ -248,7 +268,10 @@ impl GuiReplyReceiver {
             GuiReplyReceiver::VectorSource(rx) => Some(GuiReply::VectorSource(
                 rx.await.map_err(|_| REPLY_CLOSED.to_string())?,
             )),
-            GuiReplyReceiver::Path(rx) => Some(GuiReply::Path(
+            GuiReplyReceiver::DiffReview(rx) => Some(GuiReply::DiffReview(
+                rx.await.map_err(|_| REPLY_CLOSED.to_string())?,
+            )),
+            GuiReplyReceiver::DiffPatch(rx) => Some(GuiReply::DiffPatch(
                 rx.await.map_err(|_| REPLY_CLOSED.to_string())?,
             )),
         })
@@ -277,8 +300,11 @@ impl GuiRequest {
             (GuiCommand::VectorFeedback { feedback }, GuiReplySender::Unit(reply)) => {
                 GuiRequest::VectorFeedback { feedback, reply }
             }
-            (GuiCommand::DiffWorkspace, GuiReplySender::Path(reply)) => {
-                GuiRequest::DiffWorkspace { reply }
+            (GuiCommand::DiffReview { spec }, GuiReplySender::DiffReview(reply)) => {
+                GuiRequest::DiffReview { spec, reply }
+            }
+            (GuiCommand::DiffFilePatch { spec, path }, GuiReplySender::DiffPatch(reply)) => {
+                GuiRequest::DiffFilePatch { spec, path, reply }
             }
             (GuiCommand::OpenDiffBuffer { title, content }, GuiReplySender::Unit(reply)) => {
                 GuiRequest::OpenDiffBuffer {
@@ -443,9 +469,14 @@ impl GuiRequest {
                 GuiCommand::VectorFeedback { feedback },
                 GuiReplySender::Unit(reply),
             ),
-            GuiRequest::DiffWorkspace { reply } => {
-                (GuiCommand::DiffWorkspace, GuiReplySender::Path(reply))
-            }
+            GuiRequest::DiffReview { spec, reply } => (
+                GuiCommand::DiffReview { spec },
+                GuiReplySender::DiffReview(reply),
+            ),
+            GuiRequest::DiffFilePatch { spec, path, reply } => (
+                GuiCommand::DiffFilePatch { spec, path },
+                GuiReplySender::DiffPatch(reply),
+            ),
             GuiRequest::OpenDiffBuffer {
                 title,
                 content,
@@ -805,10 +836,28 @@ impl GuiBridge {
         self.unit(GuiCommand::VectorFeedback { feedback }).await
     }
 
-    pub async fn diff_workspace(&self) -> Result<PathBuf, String> {
-        match self.transport.send(GuiCommand::DiffWorkspace).await? {
-            Some(GuiReply::Path(result)) => result,
-            other => Err(mismatched_reply(GuiReplyKind::Path, other.as_ref())),
+    /// The changed-file summary for the editor's workspace, computed on the
+    /// editor's host so the repository never has to be reachable from here.
+    pub async fn diff_review(&self, spec: Option<String>) -> Result<DiffReview, String> {
+        match self.transport.send(GuiCommand::DiffReview { spec }).await? {
+            Some(GuiReply::DiffReview(result)) => result,
+            other => Err(mismatched_reply(GuiReplyKind::DiffReview, other.as_ref())),
+        }
+    }
+
+    /// The unified patch for one file of a [`GuiBridge::diff_review`] listing.
+    pub async fn diff_file_patch(
+        &self,
+        spec: Option<String>,
+        path: String,
+    ) -> Result<String, String> {
+        match self
+            .transport
+            .send(GuiCommand::DiffFilePatch { spec, path })
+            .await?
+        {
+            Some(GuiReply::DiffPatch(result)) => result,
+            other => Err(mismatched_reply(GuiReplyKind::DiffPatch, other.as_ref())),
         }
     }
 
@@ -1017,22 +1066,21 @@ mod tests {
 
     #[tokio::test]
     async fn a_rebuilt_request_answers_on_the_channel_its_command_asked_for() {
-        let command = GuiCommand::DiffWorkspace;
+        let command = GuiCommand::DiffReview {
+            spec: Some("origin/main...WORKTREE".to_string()),
+        };
         let (reply, receiver) = GuiReplySender::channel(command.reply_kind());
         let request = GuiRequest::from_parts(command, reply).unwrap();
 
-        let GuiRequest::DiffWorkspace { reply } = request else {
-            panic!("a DiffWorkspace command must rebuild a DiffWorkspace request");
+        let GuiRequest::DiffReview { spec, reply } = request else {
+            panic!("a DiffReview command must rebuild a DiffReview request");
         };
-        reply
-            .send(Ok(std::path::PathBuf::from("workspace/project")))
-            .unwrap();
+        assert_eq!(spec.as_deref(), Some("origin/main...WORKTREE"));
+        reply.send(Ok(protocol::sample_diff_review())).unwrap();
 
         assert_eq!(
             receiver.recv().await.unwrap(),
-            Some(GuiReply::Path(Ok(std::path::PathBuf::from(
-                "workspace/project"
-            ))))
+            Some(GuiReply::DiffReview(Ok(protocol::sample_diff_review())))
         );
     }
 
@@ -1076,8 +1124,11 @@ mod tests {
                             file_name: "close.strok".to_string(),
                         }));
                     }
-                    GuiReplySender::Path(tx) => {
-                        let _ = tx.send(Ok(PathBuf::from("workspace/project")));
+                    GuiReplySender::DiffReview(tx) => {
+                        let _ = tx.send(Ok(protocol::sample_diff_review()));
+                    }
+                    GuiReplySender::DiffPatch(tx) => {
+                        let _ = tx.send(Ok("@@ -1 +1 @@\n-old\n+new\n".to_string()));
                     }
                 }
                 if stopping {
@@ -1114,8 +1165,8 @@ mod tests {
             "close.strok"
         );
         assert_eq!(
-            bridge.diff_workspace().await.unwrap(),
-            PathBuf::from("workspace/project")
+            bridge.diff_review(None).await.unwrap(),
+            protocol::sample_diff_review()
         );
         bridge
             .editor_command("set number".to_string())
@@ -1132,7 +1183,7 @@ mod tests {
                     rows: 40
                 },
                 GuiCommand::VectorSource,
-                GuiCommand::DiffWorkspace,
+                GuiCommand::DiffReview { spec: None },
                 GuiCommand::EditorCommand {
                     command: "set number".to_string()
                 },
@@ -1200,9 +1251,12 @@ mod tests {
                             file_name: "close.strok".to_string(),
                         })))
                     }
-                    GuiReplyKind::Path => {
-                        Some(GuiReply::Path(Ok(PathBuf::from("workspace/project"))))
+                    GuiReplyKind::DiffReview => {
+                        Some(GuiReply::DiffReview(Ok(protocol::sample_diff_review())))
                     }
+                    GuiReplyKind::DiffPatch => Some(GuiReply::DiffPatch(Ok(
+                        "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+                    ))),
                 })
             })
         }
@@ -1239,7 +1293,17 @@ mod tests {
             .vector_feedback("lighter stroke".to_string())
             .await
             .unwrap();
-        bridge.diff_workspace().await.unwrap();
+        bridge
+            .diff_review(Some("origin/main...WORKTREE".to_string()))
+            .await
+            .unwrap();
+        bridge
+            .diff_file_patch(
+                Some("origin/main...WORKTREE".to_string()),
+                "src/main.rs".to_string(),
+            )
+            .await
+            .unwrap();
         bridge
             .open_diff_buffer(
                 "Diff · src/main.rs".to_string(),
@@ -1331,7 +1395,7 @@ mod tests {
             .into_iter()
             .filter(|command| seen.insert(discriminant(command)))
             .collect();
-        assert_eq!(expected.len(), 31, "the sweep should reach every variant");
+        assert_eq!(expected.len(), 32, "the sweep should reach every variant");
         assert_eq!(transport.received(), expected);
     }
 
@@ -1349,7 +1413,7 @@ mod tests {
             Err(EDITOR_STOPPED.to_string())
         );
         assert_eq!(bridge.vector_source().await.unwrap_err(), EDITOR_STOPPED);
-        assert_eq!(bridge.diff_workspace().await.unwrap_err(), EDITOR_STOPPED);
+        assert_eq!(bridge.diff_review(None).await.unwrap_err(), EDITOR_STOPPED);
         assert_eq!(bridge.select_tab(1).await, Err(EDITOR_STOPPED.to_string()));
         // Shutdown swallows the failure: the editor is already gone, which is
         // what shutdown was asking for.

--- a/ovim/src/gui/mod.rs
+++ b/ovim/src/gui/mod.rs
@@ -19,6 +19,7 @@ pub mod browser;
 #[cfg(feature = "gui")]
 mod menu;
 pub mod protocol;
+pub mod server;
 #[cfg(feature = "gui")]
 pub mod window;
 
@@ -461,7 +462,13 @@ fn projected_workspace_path(editor: &Editor) -> Option<std::path::PathBuf> {
         })
 }
 
-async fn handle_request(
+/// The workspace a diff command compares, or the message shown when the
+/// editor is not sitting in one.
+fn workspace_or_error(workspace: Option<std::path::PathBuf>) -> Result<std::path::PathBuf, String> {
+    workspace.ok_or_else(|| "Open a file in a Git worktree first".to_string())
+}
+
+pub(crate) async fn handle_request(
     request: GuiRequest,
     editor: &mut Editor,
     dimensions: &mut (u16, u16),
@@ -515,15 +522,29 @@ async fn handle_request(
             let result = draft_vector_feedback(editor, &feedback);
             (reply, result)
         }
-        GuiRequest::DiffWorkspace { reply } => {
-            let result = projected_workspace_path(editor)
-                .ok_or_else(|| anyhow::anyhow!("Open a file in a Git worktree first"))
-                .and_then(|path| {
-                    ovim_core::native_diff::worktree_root(&path)
-                        .map_err(|error| anyhow::anyhow!("{error:#}"))
+        GuiRequest::DiffReview { spec, reply } => {
+            // Walking Git objects is real work, so it runs on the blocking
+            // pool and answers from there. Awaiting it here would stall the
+            // editor loop -- including the snapshot tick -- for the whole walk.
+            let workspace = projected_workspace_path(editor);
+            tokio::task::spawn_blocking(move || {
+                let result = workspace_or_error(workspace).and_then(|path| {
+                    ovim_core::native_diff::review(&path, spec.as_deref())
+                        .map_err(|error| format!("{error:#}"))
                 });
-            let response = result.map_err(|error| error.to_string());
-            let _ = reply.send(response);
+                let _ = reply.send(result);
+            });
+            return;
+        }
+        GuiRequest::DiffFilePatch { spec, path, reply } => {
+            let workspace = projected_workspace_path(editor);
+            tokio::task::spawn_blocking(move || {
+                let result = workspace_or_error(workspace).and_then(|root| {
+                    ovim_core::native_diff::file_patch(&root, spec.as_deref(), &path)
+                        .map_err(|error| format!("{error:#}"))
+                });
+                let _ = reply.send(result);
+            });
             return;
         }
         GuiRequest::OpenDiffBuffer {

--- a/ovim/src/gui/mod.rs
+++ b/ovim/src/gui/mod.rs
@@ -19,6 +19,7 @@ pub mod browser;
 #[cfg(feature = "gui")]
 mod menu;
 pub mod protocol;
+pub mod remote;
 pub mod server;
 #[cfg(feature = "gui")]
 pub mod window;
@@ -39,8 +40,9 @@ pub use protocol::{
     GuiKeyInput, GuiLayoutNode, GuiLine, GuiLspEntry, GuiLspManager, GuiPane, GuiPicker,
     GuiPickerItem, GuiProblem, GuiProblemList, GuiPrompt, GuiQueuedChatInput, GuiReply,
     GuiReplyKind, GuiSegment, GuiSnapshot, GuiTab, GuiTestFailure, GuiTestPanel, GuiTheme,
-    GuiVectorSource,
+    GuiVectorSource, SNAPSHOT_EVENT,
 };
+pub use remote::{RemoteEndpoint, RemoteTransport};
 
 use crate::cli::FileArg;
 use crate::color::Color;

--- a/ovim/src/gui/mod.rs
+++ b/ovim/src/gui/mod.rs
@@ -291,7 +291,7 @@ async fn run_editor(
                 let rejected_terminal = editor.take_pending_terminal_session().is_some();
                 let rejected_shell = editor.take_pending_shell_command().is_some();
                 if rejected_terminal || rejected_shell {
-                    editor.set_status_message("External shell sessions require the TUI frontend".to_string());
+                    editor.set_status_message(SHELL_FRONTEND_REQUIRED.to_string());
                 }
                 if let Some(pending) = editor.take_pending_window_open() {
                     dispatch_window_open(pending, &window_status_tx);
@@ -463,6 +463,23 @@ fn projected_workspace_path(editor: &Editor) -> Option<std::path::PathBuf> {
                 .map(Path::to_path_buf)
         })
 }
+
+/// What an editor driven through the GUI conversation says when a command
+/// needs a terminal it cannot be handed.
+///
+/// `:terminal` and `:!cmd` queue a request for the frontend to pick up. A
+/// window can no more give one a real terminal than a headless session can, so
+/// both refuse in the same words rather than differing by transport.
+pub(crate) const SHELL_FRONTEND_REQUIRED: &str = "External shell sessions require the TUI frontend";
+
+/// What a session driven over the session API says to `:openwin`.
+///
+/// The window would open where the *editor* runs, which for a frontend on
+/// another host is the wrong machine entirely. Making the request host-aware
+/// is recorded as a follow-up; until then it is refused where it was made
+/// instead of being left queued for nobody.
+pub(crate) const WINDOW_OVER_THE_API_UNSUPPORTED: &str =
+    "Opening project windows is not supported over the session API";
 
 /// The workspace a diff command compares, or the message shown when the
 /// editor is not sitting in one.

--- a/ovim/src/gui/protocol.rs
+++ b/ovim/src/gui/protocol.rs
@@ -16,6 +16,12 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+/// The Server-Sent Events name every snapshot frame is published under.
+///
+/// Shared by the route that writes the stream and the transport that reads it,
+/// so a rename cannot leave one end silently ignoring the other.
+pub const SNAPSHOT_EVENT: &str = "snapshot";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GuiKeyInput {

--- a/ovim/src/gui/protocol.rs
+++ b/ovim/src/gui/protocol.rs
@@ -582,7 +582,19 @@ pub enum GuiCommand {
     VectorFeedback {
         feedback: String,
     },
-    DiffWorkspace,
+    /// The changed-file summary for the editor's workspace.
+    ///
+    /// The review is computed where the repository is rather than handing back
+    /// the worktree path, so a frontend on another host is never asked to open
+    /// a Git repository it cannot see.
+    DiffReview {
+        spec: Option<String>,
+    },
+    /// The patch for one file named by a [`GuiCommand::DiffReview`] listing.
+    DiffFilePatch {
+        spec: Option<String>,
+        path: String,
+    },
     OpenDiffBuffer {
         title: String,
         content: String,
@@ -690,7 +702,8 @@ impl GuiCommand {
         match self {
             GuiCommand::Snapshot { .. } => GuiReplyKind::Snapshot,
             GuiCommand::VectorSource => GuiReplyKind::VectorSource,
-            GuiCommand::DiffWorkspace => GuiReplyKind::Path,
+            GuiCommand::DiffReview { .. } => GuiReplyKind::DiffReview,
+            GuiCommand::DiffFilePatch { .. } => GuiReplyKind::DiffPatch,
             GuiCommand::Shutdown => GuiReplyKind::None,
             GuiCommand::VectorFeedback { .. }
             | GuiCommand::OpenDiffBuffer { .. }
@@ -734,7 +747,8 @@ pub enum GuiReplyKind {
     Unit,
     Snapshot,
     VectorSource,
-    Path,
+    DiffReview,
+    DiffPatch,
 }
 
 /// The answer to a [`GuiCommand`].
@@ -752,10 +766,10 @@ pub enum GuiReply {
     /// size. `Box` is transparent to serde, so the JSON is unaffected.
     Snapshot(Box<Result<GuiSnapshot, String>>),
     VectorSource(Result<GuiVectorSource, String>),
-    /// A path on the editor's host. Serializing it requires valid UTF-8, which
-    /// every path Ovim opens already is because the buffer stores paths as
-    /// `String`.
-    Path(Result<PathBuf, String>),
+    /// A changed-file summary computed on the editor's host.
+    DiffReview(Result<ovim_core::native_diff::DiffReview, String>),
+    /// A unified patch for one file, computed on the editor's host.
+    DiffPatch(Result<String, String>),
 }
 
 impl GuiReply {
@@ -765,7 +779,8 @@ impl GuiReply {
             GuiReply::Unit(_) => GuiReplyKind::Unit,
             GuiReply::Snapshot(_) => GuiReplyKind::Snapshot,
             GuiReply::VectorSource(_) => GuiReplyKind::VectorSource,
-            GuiReply::Path(_) => GuiReplyKind::Path,
+            GuiReply::DiffReview(_) => GuiReplyKind::DiffReview,
+            GuiReply::DiffPatch(_) => GuiReplyKind::DiffPatch,
         }
     }
 }
@@ -782,6 +797,24 @@ where
     let json = serde_json::to_string(value).expect("GUI protocol values serialize as JSON");
     serde_json::from_str(&json)
         .unwrap_or_else(|error| panic!("GUI protocol value did not deserialize: {error}\n{json}"))
+}
+
+/// A changed-file summary standing in for one a real repository produces.
+#[cfg(test)]
+pub(super) fn sample_diff_review() -> ovim_core::native_diff::DiffReview {
+    ovim_core::native_diff::DiffReview {
+        root: PathBuf::from("workspace/project"),
+        spec: "origin/main...WORKTREE".to_string(),
+        display_spec: "origin/main...working tree".to_string(),
+        files: vec![ovim_core::native_diff::DiffFile {
+            path: "src/main.rs".to_string(),
+            old_path: Some("src/lib.rs".to_string()),
+            status: "renamed".to_string(),
+            additions: 12,
+            deletions: 3,
+            binary: false,
+        }],
+    }
 }
 
 /// One value of every [`GuiCommand`] variant.
@@ -813,7 +846,13 @@ pub(super) fn sample_commands() -> Vec<GuiCommand> {
         GuiCommand::VectorFeedback {
             feedback: "lighter stroke".to_string(),
         },
-        GuiCommand::DiffWorkspace,
+        GuiCommand::DiffReview {
+            spec: Some("origin/main...WORKTREE".to_string()),
+        },
+        GuiCommand::DiffFilePatch {
+            spec: Some("origin/main...WORKTREE".to_string()),
+            path: "src/main.rs".to_string(),
+        },
         GuiCommand::OpenDiffBuffer {
             title: "Diff · src/main.rs".to_string(),
             content: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
@@ -901,13 +940,13 @@ mod tests {
 
     #[test]
     fn the_command_sample_covers_every_variant_exactly_once() {
-        // `GuiRequest` has 31 variants and `GuiCommand` mirrors it one for
+        // `GuiRequest` has 32 variants and `GuiCommand` mirrors it one for
         // one, so this count is what stops a new variant from being added
         // without round-trip coverage. The trailing duplicate in the sample is
         // a second `Key` with different modifiers, which is deliberate.
         let commands = sample_commands();
         let distinct: HashSet<_> = commands.iter().map(discriminant).collect();
-        assert_eq!(distinct.len(), 31);
+        assert_eq!(distinct.len(), 32);
     }
 
     #[test]
@@ -953,8 +992,10 @@ mod tests {
                 file_name: "close.strok".to_string(),
             })),
             GuiReply::VectorSource(Err("not a vector buffer".to_string())),
-            GuiReply::Path(Ok(PathBuf::from("workspace/project"))),
-            GuiReply::Path(Err("no workspace".to_string())),
+            GuiReply::DiffReview(Ok(sample_diff_review())),
+            GuiReply::DiffReview(Err("no workspace".to_string())),
+            GuiReply::DiffPatch(Ok("@@ -1 +1 @@\n-old\n+new\n".to_string())),
+            GuiReply::DiffPatch(Err("no workspace".to_string())),
             GuiReply::Snapshot(Box::new(Err("the editor stopped".to_string()))),
         ] {
             assert_eq!(round_trip(&reply), reply);
@@ -970,7 +1011,8 @@ mod tests {
                 GuiReplyKind::Unit => GuiReply::Unit(Ok(())),
                 GuiReplyKind::Snapshot => GuiReply::Snapshot(Box::new(Err("unused".to_string()))),
                 GuiReplyKind::VectorSource => GuiReply::VectorSource(Err("unused".to_string())),
-                GuiReplyKind::Path => GuiReply::Path(Err("unused".to_string())),
+                GuiReplyKind::DiffReview => GuiReply::DiffReview(Err("unused".to_string())),
+                GuiReplyKind::DiffPatch => GuiReply::DiffPatch(Err("unused".to_string())),
             };
             assert_eq!(reply.kind(), kind, "{command:?}");
         }

--- a/ovim/src/gui/protocol.rs
+++ b/ovim/src/gui/protocol.rs
@@ -759,7 +759,7 @@ pub enum GuiReplyKind {
 
 /// The answer to a [`GuiCommand`].
 ///
-/// Thirty-one commands share four reply shapes, so the reply is tagged by
+/// Thirty-two commands share five reply shapes, so the reply is tagged by
 /// shape rather than by command. Both this enum and [`GuiCommand`] use
 /// adjacent tagging: an internal tag would collide with the payload's own
 /// fields (`EditorCommand` has a `command` field) and cannot wrap a `Result`.
@@ -767,9 +767,9 @@ pub enum GuiReplyKind {
 #[serde(tag = "reply", content = "result", rename_all = "camelCase")]
 pub enum GuiReply {
     Unit(Result<(), String>),
-    /// Boxed because a projected frame dwarfs the other three replies, and
-    /// every command that returns one of those would otherwise pay for its
-    /// size. `Box` is transparent to serde, so the JSON is unaffected.
+    /// Boxed because a projected frame dwarfs the other replies, and every
+    /// command that returns one of those would otherwise pay for its size.
+    /// `Box` is transparent to serde, so the JSON is unaffected.
     Snapshot(Box<Result<GuiSnapshot, String>>),
     VectorSource(Result<GuiVectorSource, String>),
     /// A changed-file summary computed on the editor's host.

--- a/ovim/src/gui/remote.rs
+++ b/ovim/src/gui/remote.rs
@@ -1,0 +1,1088 @@
+//! Driving an editor that runs in another process.
+//!
+//! [`RemoteTransport`] carries the same conversation as
+//! [`LocalTransport`](super::LocalTransport), except that the editor is
+//! reached over the session API instead of over a pair of in-process
+//! channels: commands go out as `POST /v1/gui/command` and snapshots come
+//! back on the `GET /v1/gui/stream` Server-Sent Events feed. Nothing above
+//! [`GuiTransport`] changes shape, so every Tauri command keeps working
+//! against an editor on another host.
+//!
+//! Two properties of that API shape this module:
+//!
+//! * **The session authenticates by Host as well as by capability.**
+//!   `ApiSecurity` compares the `Host` header against the port the *server*
+//!   listens on. Under `ssh -L` the forwarded local port differs from it, so a
+//!   header derived from the URL is refused with `403`. [`RemoteEndpoint`]
+//!   therefore keeps the address dialled and the session's own port as two
+//!   separate values and always sets `Host` from the latter.
+//! * **Status describes the conversation, not the command.** A command that
+//!   failed inside the editor still answers `200` with an `Err` reply, so this
+//!   transport passes replies through untouched and only invents an error when
+//!   the link itself failed.
+
+use super::bridge::{GuiTransport, GuiTransportFuture, EDITOR_STOPPED};
+use super::protocol::{GuiCommand, GuiReply, GuiReplyKind, GuiSnapshot, SNAPSHOT_EVENT};
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use ovim_core::session::{SessionCapability, SessionInfo};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, HOST};
+use reqwest::StatusCode;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{oneshot, watch};
+
+/// The link to the editor failed, so the command never reached it.
+///
+/// [`EDITOR_STOPPED`] and `REPLY_CLOSED` are the local transport's equivalents;
+/// these read the same way on purpose, because the wording reaches the user as
+/// a Tauri command error and the user should not have to know which transport
+/// is underneath.
+const EDITOR_UNREACHABLE: &str = "The Ovim editor could not be reached";
+/// The editor answered, but not with something this frontend understands.
+const REPLY_UNREADABLE: &str = "The Ovim editor answered in a form this frontend cannot read";
+/// What a subscriber is told when the snapshot stream ends.
+///
+/// Reconnecting is R6. Until then the only honest thing to do is to say so in
+/// the status line, because a stream that stops without a word looks exactly
+/// like an editor that has become slow.
+pub const CONNECTION_LOST: &str = "Lost the connection to the remote Ovim session";
+/// A `403` from the Host guard is the one failure whose cause is impossible to
+/// guess from the status alone.
+const HOST_HINT: &str =
+    "the session accepts only its own port in the Host header, not the port dialled";
+
+/// How long the initial stream handshake may take before startup gives up.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long [`GuiTransport::send_oneway`] blocks a non-runtime caller.
+///
+/// It runs from the window's exit handler, so a hung link must not keep the
+/// process alive noticeably longer than a working one would.
+const ONEWAY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Where a remote editor is, and what proves the right to talk to it.
+///
+/// The address dialled and the session's own port are separate fields with no
+/// default relationship between them, because under an SSH tunnel they differ
+/// and getting that wrong produces a `403` whose cause is invisible.
+#[derive(Clone, Debug)]
+pub struct RemoteEndpoint {
+    /// `host:port` this process connects to.
+    address: String,
+    /// The port the session believes it is listening on, which is the only
+    /// value its Host guard accepts.
+    session_port: u16,
+    capability: SessionCapability,
+}
+
+impl RemoteEndpoint {
+    /// Address to dial, the session's own port, and its capability.
+    pub fn new(
+        address: impl Into<String>,
+        session_port: u16,
+        capability: SessionCapability,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            session_port,
+            capability,
+        }
+    }
+
+    /// Build an endpoint from the descriptor the remote session wrote.
+    ///
+    /// The descriptor is the authority for both the capability and the port,
+    /// so neither is ever typed on a command line. `address` is only the place
+    /// to dial: omitted it means the session is on this machine, and under a
+    /// forwarded port it is the local end of the tunnel.
+    pub fn from_session(session: &SessionInfo, address: Option<&str>) -> Result<Self> {
+        anyhow::ensure!(
+            session.capability.is_configured(),
+            "The remote session descriptor carries no capability, so the API would refuse every request"
+        );
+        let address = match address {
+            Some(address) => parse_address(address)?,
+            None => format!("127.0.0.1:{}", session.port),
+        };
+        Ok(Self::new(address, session.port, session.capability.clone()))
+    }
+
+    /// Read a session descriptor from disk and build an endpoint from it.
+    ///
+    /// A file rather than an argument or an environment variable: the
+    /// capability would otherwise be readable in the process table and land in
+    /// shell history, and the GUI spawns child processes that would inherit an
+    /// exported variable.
+    pub fn from_session_file(path: &Path, address: Option<&str>) -> Result<Self> {
+        let descriptor = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read the session descriptor {}", path.display()))?;
+        let session: SessionInfo = serde_json::from_str(&descriptor)
+            .with_context(|| format!("{} is not an Ovim session descriptor", path.display()))?;
+        Self::from_session(&session, address)
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://{}/v1{path}", self.address)
+    }
+
+    /// The only Host header the session's guard accepts.
+    fn host_header(&self) -> String {
+        format!("127.0.0.1:{}", self.session_port)
+    }
+
+    fn client(&self) -> Result<reqwest::Client> {
+        let mut headers = HeaderMap::new();
+        let mut authorization =
+            HeaderValue::from_str(&format!("Bearer {}", self.capability.expose_secret()))
+                .context("The session capability is not usable as an HTTP header")?;
+        authorization.set_sensitive(true);
+        headers.insert(AUTHORIZATION, authorization);
+        // Pinned here rather than at each call site: an HTTP client fills in
+        // `Host` from the URL when the request does not carry one, which is
+        // exactly the failure this transport exists to avoid.
+        headers.insert(
+            HOST,
+            HeaderValue::from_str(&self.host_header())
+                .context("The session port is not usable in a Host header")?,
+        );
+        reqwest::Client::builder()
+            .default_headers(headers)
+            // Only connecting is given a deadline. A request has no overall
+            // one because the snapshot stream is a request that stays open for
+            // as long as the session does, and an editor can sit untouched for
+            // far longer than any timeout worth choosing.
+            .connect_timeout(HANDSHAKE_TIMEOUT)
+            .build()
+            .context("Failed to build the remote session HTTP client")
+    }
+}
+
+/// Accept `host:port`, or a bare port meaning loopback.
+fn parse_address(address: &str) -> Result<String> {
+    let address = address.trim();
+    if let Ok(port) = address.parse::<u16>() {
+        return Ok(format!("127.0.0.1:{port}"));
+    }
+    let (host, port) = address
+        .rsplit_once(':')
+        .with_context(|| format!("{address} is not a HOST:PORT address"))?;
+    anyhow::ensure!(!host.is_empty(), "{address} has no host");
+    port.parse::<u16>()
+        .with_context(|| format!("{address} does not end in a port number"))?;
+    Ok(address.to_string())
+}
+
+/// The transport: an HTTP client, the stream that feeds subscribers, and the
+/// runtime both run on.
+pub struct RemoteTransport {
+    client: reqwest::Client,
+    command_url: String,
+    updates: Arc<watch::Sender<Option<GuiSnapshot>>>,
+    stream: tokio::task::JoinHandle<()>,
+    /// Owned so that requests never depend on the caller's runtime.
+    ///
+    /// Tauri polls `send` futures on its own runtime, but `send_oneway` runs
+    /// from a plain thread where there is none at all. Owning one runtime
+    /// means both paths, and the snapshot stream, use the same reactor.
+    /// `Option` only so that [`Drop`] can hand it back without blocking.
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl RemoteTransport {
+    /// Connect from a plain thread, blocking until the session answers.
+    ///
+    /// Failing here rather than in the window is the point: a wrong
+    /// capability, a wrong port, or a tunnel that is not up should read as a
+    /// startup error and not as an editor that never draws.
+    pub fn connect(endpoint: RemoteEndpoint) -> Result<Self> {
+        let (transport, ready) = Self::start(endpoint)?;
+        let handshake = transport
+            .runtime()
+            .block_on(ready)
+            .unwrap_or_else(|_| Err(EDITOR_UNREACHABLE.to_string()));
+        handshake.map_err(anyhow::Error::msg)?;
+        Ok(transport)
+    }
+
+    /// Connect from inside a runtime, where [`Self::connect`] would panic.
+    pub async fn open(endpoint: RemoteEndpoint) -> Result<Self> {
+        let (transport, ready) = Self::start(endpoint)?;
+        // Only a channel is awaited here; the request itself is made by the
+        // stream task on this transport's own runtime, so the socket never
+        // outlives the reactor that registered it.
+        let handshake = ready
+            .await
+            .unwrap_or_else(|_| Err(EDITOR_UNREACHABLE.to_string()));
+        handshake.map_err(anyhow::Error::msg)?;
+        Ok(transport)
+    }
+
+    /// Build the transport and start its stream, without waiting for it.
+    fn start(endpoint: RemoteEndpoint) -> Result<(Self, oneshot::Receiver<Result<(), String>>)> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .thread_name("ovim-gui-remote")
+            .build()
+            .context("Failed to create the remote GUI runtime")?;
+        let client = endpoint.client()?;
+        let updates = Arc::new(watch::channel(None).0);
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let stream = runtime.spawn(stream_snapshots(
+            client.clone(),
+            endpoint.url("/gui/stream"),
+            Arc::clone(&updates),
+            ready_tx,
+        ));
+        Ok((
+            Self {
+                client,
+                command_url: endpoint.url("/gui/command"),
+                updates,
+                stream,
+                runtime: Some(runtime),
+            },
+            ready_rx,
+        ))
+    }
+
+    fn runtime(&self) -> &tokio::runtime::Runtime {
+        self.runtime
+            .as_ref()
+            .expect("the runtime is taken only while dropping the transport")
+    }
+
+    /// Start the request immediately and hand back where its answer will land.
+    ///
+    /// Eager like the local transport's send: the caller's first `await` is
+    /// not what puts the command on the wire.
+    fn dispatch(&self, command: GuiCommand) -> oneshot::Receiver<Result<Option<GuiReply>, String>> {
+        let (answer_tx, answer_rx) = oneshot::channel();
+        let client = self.client.clone();
+        let url = self.command_url.clone();
+        self.runtime().spawn(async move {
+            let _ = answer_tx.send(post_command(&client, &url, command).await);
+        });
+        answer_rx
+    }
+}
+
+impl GuiTransport for RemoteTransport {
+    fn send(
+        &self,
+        command: GuiCommand,
+    ) -> GuiTransportFuture<'_, Result<Option<GuiReply>, String>> {
+        let answer = self.dispatch(command);
+        Box::pin(async move {
+            answer
+                .await
+                // The task that owns the answer is gone, which can only mean
+                // the runtime is shutting down under it.
+                .unwrap_or_else(|_| Err(EDITOR_UNREACHABLE.to_string()))
+        })
+    }
+
+    fn send_oneway(&self, command: GuiCommand) -> Result<(), String> {
+        if command.reply_kind() != GuiReplyKind::None {
+            return Err(format!(
+                "A GUI command expecting a {:?} reply cannot be sent one-way",
+                command.reply_kind()
+            ));
+        }
+        let answer = self.dispatch(command);
+        // The trait method is synchronous and HTTP is not. Blocking the
+        // *calling* thread is safe when it is a plain thread -- the request
+        // runs on this transport's own runtime, so nothing that has to make
+        // progress is being held up -- and that path returns the real outcome.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            // Inside a runtime, blocking would stall a worker that the request
+            // may itself need, so the outcome is logged instead of dropped.
+            self.runtime().spawn(async move {
+                if let Ok(Err(error)) = answer.await {
+                    ovim_core::log_warn!("gui", "One-way GUI command failed: {}", error);
+                }
+            });
+            return Ok(());
+        }
+        self.runtime().block_on(async move {
+            match tokio::time::timeout(ONEWAY_TIMEOUT, answer).await {
+                Ok(Ok(result)) => result.map(|_| ()),
+                Ok(Err(_)) => Err(EDITOR_UNREACHABLE.to_string()),
+                Err(_) => Err(format!("{EDITOR_UNREACHABLE}: it did not answer in time")),
+            }
+        })
+    }
+
+    fn subscribe(&self) -> watch::Receiver<Option<GuiSnapshot>> {
+        self.updates.subscribe()
+    }
+}
+
+impl Drop for RemoteTransport {
+    fn drop(&mut self) {
+        self.stream.abort();
+        // Dropping a runtime from inside another one panics, and a GUI shell
+        // may well be tearing this down from an async context. Handing the
+        // runtime its own shutdown avoids waiting for tasks here.
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_background();
+        }
+    }
+}
+
+/// Post one command and translate the answer.
+///
+/// `204` is a fire-and-forget command, `200` is a reply the editor produced --
+/// including one carrying an editor-level `Err`, which is passed through
+/// untouched -- and anything else is a failure of the link rather than of the
+/// command.
+async fn post_command(
+    client: &reqwest::Client,
+    url: &str,
+    command: GuiCommand,
+) -> Result<Option<GuiReply>, String> {
+    let response = client
+        .post(url)
+        .json(&command)
+        .send()
+        .await
+        .map_err(|error| format!("{EDITOR_UNREACHABLE}: {}", terse(&error)))?;
+    let status = response.status();
+    if status == StatusCode::NO_CONTENT {
+        return Ok(None);
+    }
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| format!("{EDITOR_UNREACHABLE}: {}", terse(&error)))?;
+    if status.is_success() {
+        return serde_json::from_slice::<GuiReply>(&body)
+            .map(Some)
+            .map_err(|error| format!("{REPLY_UNREADABLE}: {error}"));
+    }
+    Err(request_failure(status, &body))
+}
+
+/// Phrase a non-success answer.
+fn request_failure(status: StatusCode, body: &[u8]) -> String {
+    let reported = error_field(body);
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        // The session has already phrased this in the wording the local
+        // transport uses, so repeating it verbatim keeps a stopped editor
+        // reading the same over either transport.
+        return reported.unwrap_or_else(|| EDITOR_STOPPED.to_string());
+    }
+    let detail = match (status, reported) {
+        (StatusCode::FORBIDDEN, _) => format!("it answered {status} -- {HOST_HINT}"),
+        (_, Some(reported)) => format!("it answered {status}: {reported}"),
+        (_, None) => format!("it answered {status}"),
+    };
+    format!("{EDITOR_UNREACHABLE}: {detail}")
+}
+
+/// The `error` field every rejection in this API carries.
+fn error_field(body: &[u8]) -> Option<String> {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()?
+        .get("error")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// A network error without the chain of `source` prefixes users cannot act on.
+fn terse(error: &reqwest::Error) -> String {
+    if error.is_connect() {
+        return "the connection was refused".to_string();
+    }
+    if error.is_timeout() {
+        return "the connection timed out".to_string();
+    }
+    error.to_string()
+}
+
+/// Read snapshots from the session for as long as it keeps sending them.
+///
+/// The handshake result is reported separately from the frames so that startup
+/// can fail loudly while a later failure only has the status line to speak
+/// through.
+async fn stream_snapshots(
+    client: reqwest::Client,
+    url: String,
+    updates: Arc<watch::Sender<Option<GuiSnapshot>>>,
+    ready: oneshot::Sender<Result<(), String>>,
+) {
+    let response = match connect_stream(&client, &url).await {
+        Ok(response) => {
+            let _ = ready.send(Ok(()));
+            response
+        }
+        Err(error) => {
+            let _ = ready.send(Err(error));
+            return;
+        }
+    };
+    let reason = pump_snapshots(response, &updates).await;
+    report_connection_lost(&updates, &reason);
+}
+
+async fn connect_stream(client: &reqwest::Client, url: &str) -> Result<reqwest::Response, String> {
+    let response = tokio::time::timeout(HANDSHAKE_TIMEOUT, client.get(url).send())
+        .await
+        .map_err(|_| format!("{EDITOR_UNREACHABLE}: it did not answer in time"))?
+        .map_err(|error| format!("{EDITOR_UNREACHABLE}: {}", terse(&error)))?;
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status();
+    let body = response.bytes().await.unwrap_or_default();
+    Err(request_failure(status, &body))
+}
+
+/// Publish every snapshot frame, returning why the stream ended.
+async fn pump_snapshots(
+    response: reqwest::Response,
+    updates: &watch::Sender<Option<GuiSnapshot>>,
+) -> String {
+    let mut frames = response.bytes_stream();
+    let mut decoder = SseDecoder::default();
+    while let Some(chunk) = frames.next().await {
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => return format!("the stream failed: {}", terse(&error)),
+        };
+        for frame in decoder.push(&chunk) {
+            if frame.event != SNAPSHOT_EVENT {
+                continue;
+            }
+            match serde_json::from_str::<GuiSnapshot>(&frame.data) {
+                // `send_replace` rather than `send`: a frame is worth keeping
+                // even while no part of the frontend is listening yet.
+                Ok(snapshot) => {
+                    updates.send_replace(Some(snapshot));
+                }
+                Err(error) => {
+                    ovim_core::log_warn!("gui", "Unreadable remote snapshot: {}", error);
+                }
+            }
+        }
+    }
+    "the session closed the snapshot stream".to_string()
+}
+
+/// Say in the status line that the editor has stopped talking.
+///
+/// The subscription itself stays open, because a `watch` channel can only
+/// carry snapshots and closing it would leave the window frozen with no
+/// explanation at all. Annotating the last frame puts the reason where the
+/// user is already looking.
+fn report_connection_lost(updates: &watch::Sender<Option<GuiSnapshot>>, reason: &str) {
+    ovim_core::log_warn!("gui", "Remote snapshot stream ended: {}", reason);
+    let last = updates.borrow().clone();
+    let Some(mut frame) = last else {
+        // Nothing was ever drawn, so there is no frame to annotate. Startup
+        // reports this case through the handshake instead.
+        return;
+    };
+    frame.revision = frame.revision.wrapping_add(1);
+    frame.status_message = format!("{CONNECTION_LOST}: {reason}");
+    updates.send_replace(Some(frame));
+}
+
+/// One decoded Server-Sent Events frame.
+#[derive(Debug, PartialEq)]
+struct SseFrame {
+    event: String,
+    data: String,
+}
+
+/// A Server-Sent Events decoder, fed one network chunk at a time.
+///
+/// Hand-written rather than pulled from a crate: both ends of this stream are
+/// ours, the format in use is three field names and a blank line, and the
+/// framing edge cases that matter -- a chunk boundary inside an event,
+/// keep-alive comments, multi-line data -- are cheaper to test here than to
+/// take on a dependency for.
+#[derive(Default)]
+struct SseDecoder {
+    /// Bytes received but not yet terminated by a newline.
+    pending: Vec<u8>,
+    event: String,
+    data: String,
+}
+
+impl SseDecoder {
+    /// Feed one chunk, returning every frame it completed.
+    fn push(&mut self, chunk: &[u8]) -> Vec<SseFrame> {
+        self.pending.extend_from_slice(chunk);
+        let mut frames = Vec::new();
+        while let Some(end) = self.pending.iter().position(|byte| *byte == b'\n') {
+            let mut line: Vec<u8> = self.pending.drain(..=end).collect();
+            line.pop();
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            // A complete line cannot end mid-character, so lossy decoding here
+            // cannot mangle a multi-byte character split across two chunks.
+            if let Some(frame) = self.line(&String::from_utf8_lossy(&line)) {
+                frames.push(frame);
+            }
+        }
+        frames
+    }
+
+    /// Apply one complete line, returning a frame if it ended one.
+    fn line(&mut self, line: &str) -> Option<SseFrame> {
+        if line.is_empty() {
+            let data = std::mem::take(&mut self.data);
+            let event = std::mem::take(&mut self.event);
+            // A blank line after nothing but comments is not an event.
+            let mut data = if data.is_empty() { return None } else { data };
+            // Every data line contributed a trailing newline; the last one is
+            // a separator that was never part of the payload.
+            data.pop();
+            return Some(SseFrame { event, data });
+        }
+        if line.starts_with(':') {
+            // A comment, which is what a keep-alive is.
+            return None;
+        }
+        let (field, value) = match line.split_once(':') {
+            Some((field, value)) => (field, value.strip_prefix(' ').unwrap_or(value)),
+            None => (line, ""),
+        };
+        match field {
+            "event" => {
+                self.event.clear();
+                self.event.push_str(value);
+            }
+            "data" => {
+                self.data.push_str(value);
+                self.data.push('\n');
+            }
+            // `id` and `retry` belong to reconnection, which is R6; anything
+            // else is a field this version does not know.
+            _ => {}
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::security::{secure_router, ApiSecurity};
+    use crate::editor::Editor;
+    use crate::gui::bridge::tests::{every_command_once, exercise_every_helper};
+    use crate::gui::protocol::GuiVectorSource;
+    use crate::gui::{protocol, GuiBridge};
+    use axum::extract::State;
+    use axum::http::{HeaderMap, StatusCode as AxumStatus};
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use axum::response::{IntoResponse, Json, Response};
+    use axum::routing::{get, post};
+    use axum::{Json as JsonExtractor, Router};
+    use futures::stream::Stream;
+    use std::convert::Infallible;
+    use std::sync::Mutex;
+    use tokio::net::TcpListener;
+
+    /// The port the stub session claims to listen on.
+    ///
+    /// Deliberately not the port it is bound to: that gap is exactly what an
+    /// `ssh -L` tunnel produces, and it is what the Host guard trips over.
+    const SESSION_PORT: u16 = 4242;
+
+    /// A command whose stub answer is an editor-level failure inside a 200.
+    const FAILING_COMMAND: &str = "make the editor refuse";
+    /// A command the stub answers as a broken conversation instead.
+    const UNAVAILABLE_COMMAND: &str = "make the conversation fail";
+
+    /// A session that answers like the real one without running an editor.
+    struct StubSession {
+        received: Mutex<Vec<GuiCommand>>,
+        hosts: Mutex<Vec<String>>,
+        snapshot: GuiSnapshot,
+        updates: watch::Sender<Option<GuiSnapshot>>,
+        stop: watch::Sender<bool>,
+    }
+
+    impl StubSession {
+        fn received(&self) -> Vec<GuiCommand> {
+            self.received.lock().unwrap().clone()
+        }
+
+        /// Push a frame to whoever is streaming.
+        fn publish(&self, status_message: &str) {
+            let mut snapshot = self.snapshot.clone();
+            snapshot.revision += 1;
+            snapshot.status_message = status_message.to_string();
+            self.updates.send_replace(Some(snapshot));
+        }
+
+        /// End the snapshot stream the way a dropped link would.
+        fn close_stream(&self) {
+            self.stop.send_replace(true);
+        }
+    }
+
+    async fn stub_command(
+        State(stub): State<Arc<StubSession>>,
+        headers: HeaderMap,
+        JsonExtractor(command): JsonExtractor<GuiCommand>,
+    ) -> Response {
+        stub.hosts.lock().unwrap().push(
+            headers
+                .get(HOST)
+                .and_then(|host| host.to_str().ok())
+                .unwrap_or_default()
+                .to_string(),
+        );
+        let kind = command.reply_kind();
+        let scripted = match &command {
+            GuiCommand::EditorCommand { command } => command.clone(),
+            _ => String::new(),
+        };
+        stub.received.lock().unwrap().push(command);
+        if scripted == UNAVAILABLE_COMMAND {
+            return (
+                AxumStatus::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": EDITOR_STOPPED })),
+            )
+                .into_response();
+        }
+        if scripted == FAILING_COMMAND {
+            return Json(GuiReply::Unit(Err(
+                "Not an editor command: nope".to_string()
+            )))
+            .into_response();
+        }
+        match kind {
+            GuiReplyKind::None => AxumStatus::NO_CONTENT.into_response(),
+            GuiReplyKind::Unit => Json(GuiReply::Unit(Ok(()))).into_response(),
+            GuiReplyKind::Snapshot => {
+                Json(GuiReply::Snapshot(Box::new(Ok(stub.snapshot.clone())))).into_response()
+            }
+            GuiReplyKind::VectorSource => Json(GuiReply::VectorSource(Ok(GuiVectorSource {
+                source: "documentsize 24x24\n".to_string(),
+                file_name: "close.strok".to_string(),
+            })))
+            .into_response(),
+            GuiReplyKind::DiffReview => {
+                Json(GuiReply::DiffReview(Ok(protocol::sample_diff_review()))).into_response()
+            }
+            GuiReplyKind::DiffPatch => Json(GuiReply::DiffPatch(Ok(
+                "@@ -1 +1 @@\n-old\n+new\n".to_string()
+            )))
+            .into_response(),
+        }
+    }
+
+    async fn stub_stream(
+        State(stub): State<Arc<StubSession>>,
+    ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+        let updates = stub.updates.subscribe();
+        let stop = stub.stop.subscribe();
+        let frames =
+            futures::stream::unfold((updates, stop), |(mut updates, mut stop)| async move {
+                loop {
+                    if *stop.borrow_and_update() {
+                        return None;
+                    }
+                    tokio::select! {
+                        _ = stop.changed() => return None,
+                        changed = updates.changed() => changed.ok()?,
+                    }
+                    let frame = updates.borrow_and_update().clone();
+                    if let Some(snapshot) = frame {
+                        let event = Event::default()
+                            .event(SNAPSHOT_EVENT)
+                            .json_data(&snapshot)
+                            .expect("a snapshot serializes");
+                        return Some((Ok(event), (updates, stop)));
+                    }
+                }
+            });
+        Sse::new(frames).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+    }
+
+    /// Serve a stub session on a loopback port, behind the real security layer.
+    ///
+    /// The security layer is the real one on purpose: the Host guard is the
+    /// single most confusing way a remote transport can fail, and a stub guard
+    /// would only prove that the test agrees with itself.
+    async fn stub_session() -> (Arc<StubSession>, RemoteEndpoint) {
+        let capability = SessionCapability::generate();
+        let stub = Arc::new(StubSession {
+            received: Mutex::new(Vec::new()),
+            hosts: Mutex::new(Vec::new()),
+            snapshot: super::super::snapshot(&Editor::with_content("fn main() {}\n"), 1),
+            updates: watch::channel(None).0,
+            stop: watch::channel(false).0,
+        });
+        let routes = Router::new()
+            .route("/gui/command", post(stub_command))
+            .route("/gui/stream", get(stub_stream))
+            .with_state(Arc::clone(&stub));
+        let app = secure_router(
+            Router::new().nest("/v1", routes),
+            ApiSecurity::new(capability.clone(), SESSION_PORT),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (
+            stub,
+            RemoteEndpoint::new(address.to_string(), SESSION_PORT, capability),
+        )
+    }
+
+    /// Wait for a condition the stub reaches on another task.
+    async fn eventually(mut ready: impl FnMut() -> bool) {
+        for _ in 0..200 {
+            if ready() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("the stub session never reached the expected state");
+    }
+
+    #[tokio::test]
+    async fn a_command_comes_back_as_the_reply_shape_it_declared() {
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+
+        for command in [
+            GuiCommand::Snapshot {
+                columns: 120,
+                rows: 40,
+            },
+            GuiCommand::VectorSource,
+            GuiCommand::DiffReview { spec: None },
+            GuiCommand::DiffFilePatch {
+                spec: None,
+                path: "src/main.rs".to_string(),
+            },
+            GuiCommand::SelectTab { index: 3 },
+        ] {
+            let reply = transport
+                .send(command.clone())
+                .await
+                .unwrap_or_else(|error| panic!("{command:?}: {error}"));
+            assert_eq!(
+                reply.as_ref().map(GuiReply::kind),
+                Some(command.reply_kind()),
+                "{command:?}"
+            );
+        }
+        assert_eq!(stub.received().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn an_editor_level_failure_arrives_as_the_error_the_editor_wrote() {
+        // The session answers 200 for a command the editor refused, because
+        // the status describes the conversation and not the command. A
+        // transport that read the status instead would turn a typo in an ex
+        // command into a connection error.
+        let (_stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let bridge = GuiBridge::new(Arc::new(transport));
+
+        let error = bridge
+            .editor_command(FAILING_COMMAND.to_string())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, "Not an editor command: nope");
+    }
+
+    #[tokio::test]
+    async fn a_fire_and_forget_command_is_answered_with_no_reply_at_all() {
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+
+        let reply = transport.send(GuiCommand::Shutdown).await.unwrap();
+
+        assert_eq!(reply, None);
+        assert_eq!(stub.received(), vec![GuiCommand::Shutdown]);
+    }
+
+    #[tokio::test]
+    async fn a_broken_conversation_reads_exactly_as_a_stopped_local_editor_does() {
+        // The wording reaches the user as a Tauri command error, and the user
+        // should not have to know which transport is underneath.
+        let (_stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let bridge = GuiBridge::new(Arc::new(transport));
+
+        let error = bridge
+            .editor_command(UNAVAILABLE_COMMAND.to_string())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, EDITOR_STOPPED);
+    }
+
+    #[tokio::test]
+    async fn a_session_that_is_not_listening_is_reported_at_startup() {
+        // Binding and dropping a listener yields a port nothing answers on.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let endpoint = RemoteEndpoint::new(
+            address.to_string(),
+            SESSION_PORT,
+            SessionCapability::generate(),
+        );
+
+        let error = RemoteTransport::open(endpoint)
+            .await
+            .err()
+            .expect("a port nothing listens on cannot be connected to")
+            .to_string();
+
+        assert!(error.starts_with(EDITOR_UNREACHABLE), "{error}");
+    }
+
+    #[tokio::test]
+    async fn every_typed_helper_reaches_the_session_as_the_command_it_is_named_for() {
+        // The same sweep the local transport is held to, run over a socket:
+        // anything the wire format loses or reorders shows up as a difference
+        // against the protocol's own list of commands.
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let bridge = GuiBridge::new(Arc::new(transport));
+
+        exercise_every_helper(&bridge).await;
+
+        // The sweep ends with a one-way shutdown, which by definition is not
+        // waited for.
+        let expected = every_command_once();
+        let arrived = Arc::clone(&stub);
+        eventually(|| arrived.received().len() == expected.len()).await;
+        assert_eq!(stub.received(), expected);
+    }
+
+    #[tokio::test]
+    async fn a_command_that_expects_an_answer_cannot_be_sent_one_way() {
+        // Same contract as the local transport: a one-way send has nowhere to
+        // put an answer, so a command that has one must be refused rather than
+        // have it dropped in silence.
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+
+        let error = transport
+            .send_oneway(GuiCommand::SelectTab { index: 1 })
+            .unwrap_err();
+
+        assert!(error.contains("Unit"), "{error}");
+        assert!(stub.received().is_empty(), "nothing should have been sent");
+    }
+
+    #[tokio::test]
+    async fn the_host_header_names_the_port_the_session_listens_on_not_the_one_dialled() {
+        // The single most likely thing to regress here, and its failure mode
+        // is a 403 that says nothing about ports. The stub is bound to an
+        // ephemeral port and only claims SESSION_PORT, so a Host derived from
+        // the URL would never have got past the guard at all.
+        let (stub, endpoint) = stub_session().await;
+        assert_ne!(
+            endpoint.address,
+            format!("127.0.0.1:{SESSION_PORT}"),
+            "the test only means something while the two ports differ"
+        );
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+
+        transport
+            .send(GuiCommand::SelectTab { index: 0 })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            stub.hosts.lock().unwrap().clone(),
+            vec![format!("127.0.0.1:{SESSION_PORT}")]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_transport_that_names_the_wrong_port_is_refused_and_says_why() {
+        let (_stub, endpoint) = stub_session().await;
+        let mistaken = RemoteEndpoint::new(
+            endpoint.address.clone(),
+            SESSION_PORT + 1,
+            endpoint.capability.clone(),
+        );
+
+        let error = RemoteTransport::open(mistaken)
+            .await
+            .err()
+            .expect("the Host guard refuses a port the session does not listen on")
+            .to_string();
+
+        assert!(error.contains("403"), "{error}");
+        assert!(error.contains("Host header"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn a_snapshot_published_by_the_session_reaches_a_subscriber() {
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let mut updates = transport.subscribe();
+
+        stub.publish("saved");
+
+        tokio::time::timeout(Duration::from_secs(5), updates.changed())
+            .await
+            .expect("a published frame should arrive")
+            .unwrap();
+        let frame = updates.borrow_and_update().clone().unwrap();
+        assert_eq!(frame.status_message, "saved");
+        assert_eq!(frame.lines, stub.snapshot.lines);
+    }
+
+    #[tokio::test]
+    async fn a_stream_that_dies_says_so_rather_than_going_quiet() {
+        // Reconnection is R6. Until then a dropped link must at least reach
+        // the status line, because a stream that stops without a word is
+        // indistinguishable from an editor that has become slow.
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let mut updates = transport.subscribe();
+        stub.publish("saved");
+        tokio::time::timeout(Duration::from_secs(5), updates.changed())
+            .await
+            .expect("a published frame should arrive")
+            .unwrap();
+
+        stub.close_stream();
+
+        tokio::time::timeout(Duration::from_secs(5), updates.changed())
+            .await
+            .expect("the end of the stream should be reported")
+            .unwrap();
+        let frame = updates.borrow_and_update().clone().unwrap();
+        assert!(
+            frame.status_message.starts_with(CONNECTION_LOST),
+            "{:?}",
+            frame.status_message
+        );
+        // The last frame is otherwise left alone, so the window keeps showing
+        // what the editor last said rather than blanking.
+        assert_eq!(frame.lines, stub.snapshot.lines);
+    }
+
+    #[test]
+    fn an_address_may_be_a_bare_port_a_host_and_port_or_nothing_usable() {
+        assert_eq!(parse_address("9000").unwrap(), "127.0.0.1:9000");
+        assert_eq!(parse_address(" 127.0.0.1:9000 ").unwrap(), "127.0.0.1:9000");
+        assert_eq!(parse_address("build-host:9000").unwrap(), "build-host:9000");
+        assert!(parse_address("build-host").is_err());
+        assert!(parse_address("build-host:ssh").is_err());
+    }
+
+    #[test]
+    fn a_descriptor_without_a_capability_cannot_produce_an_endpoint() {
+        // Such a session predates authentication or was hand-written; dialling
+        // it could only end in a 401, so it is refused where the file is read.
+        let session = SessionInfo {
+            capability: SessionCapability::default(),
+            ..SessionInfo::new(9000, None, "dev".to_string())
+        };
+
+        let error = RemoteEndpoint::from_session(&session, None).unwrap_err();
+
+        assert!(error.to_string().contains("capability"), "{error}");
+    }
+
+    #[test]
+    fn an_endpoint_defaults_to_the_port_the_session_reported() {
+        let session = SessionInfo::new(9000, None, "dev".to_string())
+            .with_capability(SessionCapability::generate());
+
+        let endpoint = RemoteEndpoint::from_session(&session, None).unwrap();
+
+        assert_eq!(endpoint.address, "127.0.0.1:9000");
+        assert_eq!(endpoint.host_header(), "127.0.0.1:9000");
+    }
+
+    #[test]
+    fn a_forwarded_port_changes_where_to_dial_but_never_the_host_header() {
+        let session = SessionInfo::new(9000, None, "dev".to_string())
+            .with_capability(SessionCapability::generate());
+
+        let endpoint = RemoteEndpoint::from_session(&session, Some("41000")).unwrap();
+
+        assert_eq!(endpoint.address, "127.0.0.1:41000");
+        assert_eq!(endpoint.host_header(), "127.0.0.1:9000");
+    }
+
+    fn decode(decoder: &mut SseDecoder, chunk: &str) -> Vec<SseFrame> {
+        decoder.push(chunk.as_bytes())
+    }
+
+    #[test]
+    fn an_event_split_across_chunks_is_decoded_once_the_blank_line_arrives() {
+        let mut decoder = SseDecoder::default();
+
+        assert!(decode(&mut decoder, "event: snap").is_empty());
+        assert!(decode(&mut decoder, "shot\ndata: {\"a\"").is_empty());
+        // The event is complete only at the blank line, not at the newline
+        // that ends its last field.
+        assert!(decode(&mut decoder, ":1}\n").is_empty());
+        assert_eq!(
+            decode(&mut decoder, "\n"),
+            vec![SseFrame {
+                event: "snapshot".to_string(),
+                data: "{\"a\":1}".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn keep_alive_comments_and_unknown_fields_are_ignored() {
+        let mut decoder = SseDecoder::default();
+
+        // A keep-alive is a comment followed by a blank line, which must not
+        // be mistaken for an event with empty data.
+        assert!(decode(&mut decoder, ":\n\n").is_empty());
+        assert_eq!(
+            decode(
+                &mut decoder,
+                "id: 7\nretry: 500\nevent: snapshot\ndata: x\n\n"
+            ),
+            vec![SseFrame {
+                event: "snapshot".to_string(),
+                data: "x".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn a_multi_line_data_field_is_rejoined_with_the_newlines_it_encoded() {
+        let mut decoder = SseDecoder::default();
+
+        // Carriage returns are line terminators here, not payload, and two
+        // events in one chunk are two events.
+        let frames = decode(
+            &mut decoder,
+            "event: snapshot\r\ndata: one\r\ndata: two\r\n\r\nevent: snapshot\ndata: three\n\n",
+        );
+
+        assert_eq!(
+            frames,
+            vec![
+                SseFrame {
+                    event: "snapshot".to_string(),
+                    data: "one\ntwo".to_string(),
+                },
+                SseFrame {
+                    event: "snapshot".to_string(),
+                    data: "three".to_string(),
+                },
+            ]
+        );
+    }
+}

--- a/ovim/src/gui/server.rs
+++ b/ovim/src/gui/server.rs
@@ -1,0 +1,264 @@
+//! The editor conversation, served from a headless session.
+//!
+//! The desktop GUI runs its own editor loop ([`super::run_editor`]) and answers
+//! [`GuiRequest`]s from it directly. A headless session already owns an editor
+//! for the automation API, so rather than starting a second loop it grows a
+//! second conversation: [`GuiServer`] plugs the same request handling and the
+//! same snapshot publishing into `run_headless_loop`, and [`GuiChannel`] is the
+//! handle the HTTP layer talks to.
+//!
+//! Nothing here depends on Tauri. That is the point: the host that runs the
+//! editor needs no window server, and a frontend on another machine reaches it
+//! over the session API instead of over a pair of in-process channels.
+
+use super::bridge::EDITOR_STOPPED;
+use super::protocol::{GuiCommand, GuiReply, GuiSnapshot};
+use super::{GuiReplySender, GuiRequest};
+use crate::editor::Editor;
+use std::sync::Arc;
+use tokio::sync::{mpsc, watch};
+
+/// Build the two ends of a headless GUI conversation.
+///
+/// `dimensions` is the viewport the session already established, so the first
+/// projected frame matches what `/v1/resize` and `/v1/render` see.
+pub fn gui_channel(dimensions: (u16, u16)) -> (GuiChannel, GuiServer) {
+    let (requests, incoming) = mpsc::unbounded_channel();
+    // The publishing end is shared rather than split in two. The event loop
+    // sends frames through it; the HTTP layer subscribes through it and asks
+    // it how many subscribers exist, which is the entire laziness signal.
+    // Dropping the initial receiver is deliberate -- with it retained the
+    // count would never fall back to zero.
+    let updates = Arc::new(watch::channel(None).0);
+    (
+        GuiChannel {
+            requests,
+            updates: Arc::clone(&updates),
+        },
+        GuiServer {
+            incoming,
+            updates,
+            dimensions,
+            revision: 1,
+            last_snapshot: None,
+            last_render_version: 0,
+            frames_built: 0,
+        },
+    )
+}
+
+/// The caller's end of a headless GUI conversation.
+///
+/// Held by the Axum handlers, which are the only things on this side.
+#[derive(Clone)]
+pub struct GuiChannel {
+    requests: mpsc::UnboundedSender<GuiRequest>,
+    updates: Arc<watch::Sender<Option<GuiSnapshot>>>,
+}
+
+impl GuiChannel {
+    /// Send one command and wait for the answer its
+    /// [`reply_kind`](GuiCommand::reply_kind) promises.
+    ///
+    /// `Ok(None)` means the command is fire-and-forget and there was never an
+    /// answer to wait for. The failure wording matches
+    /// [`LocalTransport`](super::LocalTransport) so a remote frontend reads the
+    /// same message as an in-process one.
+    pub async fn send(&self, command: GuiCommand) -> Result<Option<GuiReply>, String> {
+        let (reply, receiver) = GuiReplySender::channel(command.reply_kind());
+        let request = GuiRequest::from_parts(command, reply)?;
+        self.requests
+            .send(request)
+            .map_err(|_| EDITOR_STOPPED.to_string())?;
+        receiver.recv().await
+    }
+
+    /// Watch coalesced editor-state changes.
+    ///
+    /// Subscribing is what makes the session start projecting frames at all,
+    /// and dropping the receiver is what makes it stop.
+    pub fn subscribe(&self) -> watch::Receiver<Option<GuiSnapshot>> {
+        self.updates.subscribe()
+    }
+}
+
+/// The editor's end of a headless GUI conversation.
+///
+/// Driven by `run_headless_loop`: one [`GuiServer::recv`] arm in its `select!`,
+/// and a [`GuiServer::publish`] call after anything that could have changed the
+/// projection.
+pub struct GuiServer {
+    incoming: mpsc::UnboundedReceiver<GuiRequest>,
+    updates: Arc<watch::Sender<Option<GuiSnapshot>>>,
+    dimensions: (u16, u16),
+    revision: u64,
+    /// The last frame published, or `None` while nothing is being streamed.
+    last_snapshot: Option<GuiSnapshot>,
+    last_render_version: u64,
+    frames_built: u64,
+}
+
+impl GuiServer {
+    /// Await the next command, or `None` once every [`GuiChannel`] is gone.
+    pub async fn recv(&mut self) -> Option<GuiRequest> {
+        self.incoming.recv().await
+    }
+
+    /// Answer one command, reporting whether the session should keep running.
+    ///
+    /// `Shutdown` is the only command that stops it. A frontend closing its
+    /// window must therefore not send one if it wants the session to survive
+    /// for a later reconnect.
+    pub async fn handle(&mut self, request: GuiRequest, editor: &mut Editor) -> bool {
+        if matches!(request, GuiRequest::Shutdown) {
+            return false;
+        }
+        super::handle_request(request, editor, &mut self.dimensions, &mut self.revision).await;
+        true
+    }
+
+    /// Publish a frame if the projection changed -- and only while somebody is
+    /// watching.
+    ///
+    /// A headless session used purely for automation must not pay to build
+    /// `GuiSnapshot`s nobody reads, so the subscriber count gates the
+    /// projection itself and not merely the send. When the last subscriber
+    /// leaves, the published frame is cleared: the next subscriber then cannot
+    /// be handed a stale frame from a previous connection, and because no frame
+    /// is on record any more the first tick after it arrives projects a fresh
+    /// one regardless of whether the editor changed meanwhile.
+    pub fn publish(&mut self, editor: &Editor) {
+        if self.updates.receiver_count() == 0 {
+            if self.last_snapshot.take().is_some() {
+                self.updates.send_replace(None);
+            }
+            return;
+        }
+
+        let render_version = editor.render_input_version();
+        if self.last_snapshot.is_some() && render_version == self.last_render_version {
+            return;
+        }
+        self.last_render_version = render_version;
+        // Project at the current revision so a runtime tick that did not touch
+        // the visible state costs a comparison rather than a wire frame.
+        self.frames_built += 1;
+        let mut next = super::snapshot(editor, self.revision);
+        if self.last_snapshot.as_ref() == Some(&next) {
+            return;
+        }
+        self.revision = self.revision.wrapping_add(1);
+        next.revision = self.revision;
+        self.last_snapshot = Some(next.clone());
+        self.updates.send_replace(Some(next));
+    }
+
+    /// How many frames this session has projected.
+    ///
+    /// The honest measure of laziness: an unwatched session must never raise
+    /// it, however much the editor underneath is changing.
+    pub fn frames_built(&self) -> u64 {
+        self.frames_built
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::protocol::GuiReplyKind;
+
+    /// Move the editor's visible state on, the way an edit would.
+    fn changed(editor: &mut Editor, message: &str) {
+        editor.set_status_message(message.to_string());
+        editor.mark_dirty();
+    }
+
+    #[tokio::test]
+    async fn a_session_nobody_is_watching_projects_no_frames() {
+        let (_channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        for index in 0..5 {
+            changed(&mut editor, &format!("edit {index}"));
+            server.publish(&editor);
+        }
+
+        assert_eq!(server.frames_built(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_subscriber_gets_a_frame_even_though_the_editor_did_not_change() {
+        // The race a client would otherwise lose: it connects to a session
+        // that was idle, and nothing edits the buffer afterwards.
+        let (channel, mut server) = gui_channel((80, 24));
+        let editor = Editor::with_content("fn main() {}\n");
+        server.publish(&editor);
+        assert_eq!(server.frames_built(), 0);
+
+        let mut updates = channel.subscribe();
+        server.publish(&editor);
+
+        assert_eq!(server.frames_built(), 1);
+        assert!(updates.borrow_and_update().is_some());
+    }
+
+    #[tokio::test]
+    async fn the_last_subscriber_leaving_stops_projection_and_clears_the_frame() {
+        // A frame kept past the last disconnect would be served to the next
+        // subscriber as if it were current.
+        let (channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+        let updates = channel.subscribe();
+        server.publish(&editor);
+        let published = server.frames_built();
+
+        drop(updates);
+        changed(&mut editor, "saved");
+        server.publish(&editor);
+
+        assert_eq!(server.frames_built(), published);
+        assert!(channel.subscribe().borrow().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_command_reaches_the_editor_and_answers_with_its_declared_shape() {
+        let (channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+        let sent = tokio::spawn(async move {
+            channel
+                .send(GuiCommand::EditorCommand {
+                    command: "set number".to_string(),
+                })
+                .await
+        });
+
+        let request = server.recv().await.expect("the command should arrive");
+        assert!(server.handle(request, &mut editor).await);
+
+        let reply = sent.await.unwrap().unwrap().expect("a unit reply");
+        assert_eq!(reply.kind(), GuiReplyKind::Unit);
+    }
+
+    #[tokio::test]
+    async fn a_shutdown_command_ends_the_session_without_an_answer() {
+        let (channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+        let sent = tokio::spawn(async move { channel.send(GuiCommand::Shutdown).await });
+
+        let request = server.recv().await.expect("the command should arrive");
+        assert!(!server.handle(request, &mut editor).await);
+
+        assert_eq!(sent.await.unwrap(), Ok(None));
+    }
+
+    #[tokio::test]
+    async fn a_command_sent_to_a_stopped_session_reads_as_a_stopped_editor() {
+        let (channel, server) = gui_channel((80, 24));
+        drop(server);
+
+        assert_eq!(
+            channel.send(GuiCommand::SelectTab { index: 1 }).await,
+            Err(EDITOR_STOPPED.to_string())
+        );
+    }
+}

--- a/ovim/src/gui/server.rs
+++ b/ovim/src/gui/server.rs
@@ -114,6 +114,7 @@ impl GuiServer {
             return false;
         }
         super::handle_request(request, editor, &mut self.dimensions, &mut self.revision).await;
+        refuse_frontend_only_requests(editor);
         true
     }
 
@@ -159,6 +160,30 @@ impl GuiServer {
     /// it, however much the editor underneath is changing.
     pub fn frames_built(&self) -> u64 {
         self.frames_built
+    }
+}
+
+/// Consume the requests only an interactive frontend can carry out.
+///
+/// `:terminal`, `:!cmd` and `:openwin` do not act; they queue a request for
+/// the frontend to pick up on its next turn round the loop. This session has
+/// no terminal to hand over and no window server of its own, and a request
+/// left queued is worse than a refused one: `execute_command_string_api`
+/// consumes a queued terminal or window request on the *next* ex command and
+/// fails in its place, so an unrelated `:set number` sent afterwards comes
+/// back as an error and never runs.
+///
+/// The local GUI loop drains the same three after every request, which is why
+/// a window driving an editor in this process already behaves correctly. This
+/// keeps a frontend on the other end of the API from behaving differently.
+fn refuse_frontend_only_requests(editor: &mut Editor) {
+    let terminal = editor.take_pending_terminal_session().is_some();
+    let shell = editor.take_pending_shell_command().is_some();
+    if terminal || shell {
+        editor.set_status_message(super::SHELL_FRONTEND_REQUIRED.to_string());
+    }
+    if editor.take_pending_window_open().is_some() {
+        editor.set_status_message(super::WINDOW_OVER_THE_API_UNSUPPORTED.to_string());
     }
 }
 
@@ -218,6 +243,118 @@ mod tests {
 
         assert_eq!(server.frames_built(), published);
         assert!(channel.subscribe().borrow().is_none());
+    }
+
+    /// One keystroke, the way a window sends it.
+    fn typed(key: &str) -> crate::gui::GuiKeyInput {
+        crate::gui::GuiKeyInput {
+            key: key.to_string(),
+            shift: false,
+            control: false,
+            alt: false,
+            meta: false,
+        }
+    }
+
+    /// Answer one command the way `run_headless_loop` does.
+    ///
+    /// The reply travels a `oneshot`, which holds the value, so it can be
+    /// collected after `handle` returns rather than from another task.
+    async fn serve(
+        server: &mut GuiServer,
+        editor: &mut Editor,
+        command: GuiCommand,
+    ) -> Result<Option<GuiReply>, String> {
+        let (reply, receiver) = super::super::GuiReplySender::channel(command.reply_kind());
+        let request = GuiRequest::from_parts(command, reply).expect("a matching reply channel");
+        server.handle(request, editor).await;
+        receiver.recv().await
+    }
+
+    /// Type an ex command at the editor's command line, key by key.
+    async fn type_ex_command(server: &mut GuiServer, editor: &mut Editor, command: &str) {
+        let mut keys: Vec<String> = command.chars().map(|c| c.to_string()).collect();
+        keys.push("Enter".to_string());
+        for key in keys {
+            serve(server, editor, GuiCommand::Key { input: typed(&key) })
+                .await
+                .expect("a keystroke should reach the editor");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_terminal_typed_at_the_command_line_is_refused_instead_of_poisoning_the_next_command()
+    {
+        // `:terminal` queues a request for an interactive frontend. Left
+        // queued, the *next* ex command through the API consumes it and fails
+        // in its place -- so an unrelated `set number` came back as an error
+        // and never ran, which is a failure with no visible cause at all.
+        let (_channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        type_ex_command(&mut server, &mut editor, ":terminal").await;
+
+        assert_eq!(
+            editor.status_message().trim(),
+            super::super::SHELL_FRONTEND_REQUIRED,
+            "the refusal belongs on the command that asked for it"
+        );
+        let reply = serve(
+            &mut server,
+            &mut editor,
+            GuiCommand::EditorCommand {
+                command: "set number".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(reply, Some(GuiReply::Unit(Ok(()))));
+        assert!(
+            editor.options.number,
+            "the next command has to actually run"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_shell_command_typed_at_the_command_line_is_refused_rather_than_dropped() {
+        // Nothing else ever takes this one, so leaving it queued means `:!cmd`
+        // does nothing and says nothing. The local GUI refuses it in words.
+        let (_channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        type_ex_command(&mut server, &mut editor, ":!echo hello").await;
+
+        assert_eq!(
+            editor.status_message().trim(),
+            super::super::SHELL_FRONTEND_REQUIRED
+        );
+    }
+
+    #[tokio::test]
+    async fn opening_a_project_window_is_refused_by_a_session_driven_over_the_api() {
+        // The window would open where the editor runs, which for a frontend on
+        // another host is the wrong machine; and left queued it would fail the
+        // next ex command instead of this one.
+        let (_channel, mut server) = gui_channel((80, 24));
+        let mut editor = Editor::with_content("fn main() {}\n");
+
+        type_ex_command(&mut server, &mut editor, ":openwin").await;
+
+        assert_eq!(
+            editor.status_message().trim(),
+            super::super::WINDOW_OVER_THE_API_UNSUPPORTED
+        );
+        let reply = serve(
+            &mut server,
+            &mut editor,
+            GuiCommand::EditorCommand {
+                command: "set number".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(reply, Some(GuiReply::Unit(Ok(()))));
+        assert!(editor.options.number);
     }
 
     #[tokio::test]

--- a/ovim/src/main.rs
+++ b/ovim/src/main.rs
@@ -223,9 +223,14 @@ async fn main() -> Result<()> {
         let (port_tx, port_rx) = tokio::sync::oneshot::channel();
         let capability = SessionCapability::generate();
         let server_capability = capability.clone();
+        // The GUI conversation rides the same authenticated listener, so a
+        // frontend on another host reaches this editor through `/v1/gui/*`.
+        let headless_dimensions = dimension.unwrap_or((120, 35));
+        let (gui_channel, gui_server) = ovim::gui::server::gui_channel(headless_dimensions);
         tokio::spawn(async move {
             if let Err(e) =
-                ovim::api::start_server("127.0.0.1:0", tx, port_tx, server_capability).await
+                ovim::api::start_server("127.0.0.1:0", tx, port_tx, server_capability, gui_channel)
+                    .await
             {
                 ovim_core::lsp_error!("API", "API server error: {}", e);
             }
@@ -236,7 +241,6 @@ async fn main() -> Result<()> {
         editor.set_api_port(port);
 
         let file_path = file_arg.map(|f| f.path);
-        let headless_dimensions = dimension.unwrap_or((120, 35));
         let session_info = SessionInfo::new(port, file_path, session_name.clone())
             .with_capability(capability)
             .with_dimensions(headless_dimensions.0, headless_dimensions.1);
@@ -307,6 +311,7 @@ async fn main() -> Result<()> {
             start_time,
             session_info_arc,
             headless_dimensions,
+            gui_server,
             shutdown_rx,
         )
         .await?;

--- a/ovim/src/subcommands.rs
+++ b/ovim/src/subcommands.rs
@@ -158,7 +158,12 @@ fn expand_escapes(s: &str) -> String {
 /// Execute a subcommand
 pub fn execute_subcommand(command: Command) -> Result<()> {
     match command {
-        Command::Gui { file, resume } => cmd_gui(file, resume),
+        Command::Gui {
+            file,
+            resume,
+            remote_session,
+            remote_endpoint,
+        } => cmd_gui(file, resume, remote_session, remote_endpoint),
 
         // File operations (direct file I/O, no session needed)
         Command::Edit {
@@ -240,14 +245,26 @@ pub fn execute_subcommand(command: Command) -> Result<()> {
 
 /// Run the native shell in-process so `ovim gui` works in source builds,
 /// standalone CLI distributions, and desktop packages without path probing.
-fn cmd_gui(file: Option<String>, resume: bool) -> Result<()> {
+fn cmd_gui(
+    file: Option<String>,
+    resume: bool,
+    remote_session: Option<std::path::PathBuf>,
+    remote_endpoint: Option<String>,
+) -> Result<()> {
+    // Resolved before the window exists, so an unreadable descriptor is a
+    // startup error naming the file rather than a window that never draws.
+    let remote = remote_session
+        .map(|path| {
+            crate::gui::RemoteEndpoint::from_session_file(&path, remote_endpoint.as_deref())
+        })
+        .transpose()?;
     #[cfg(feature = "gui")]
     {
-        crate::gui::app::run(file.as_deref().map(FileArg::parse), resume)
+        crate::gui::app::run(file.as_deref().map(FileArg::parse), resume, remote)
     }
     #[cfg(not(feature = "gui"))]
     {
-        let _ = (file, resume);
+        let _ = (file, resume, remote);
         anyhow::bail!("This Ovim build does not include the native GUI feature")
     }
 }

--- a/ovim/tests/remote_session_test.rs
+++ b/ovim/tests/remote_session_test.rs
@@ -1,0 +1,120 @@
+//! Driving a real session over the remote transport.
+//!
+//! Ignored by default because it needs an editor that is already running, and
+//! a test that starts one would be timing out on somebody's laptop rather than
+//! testing the transport. Run it against a live session with:
+//!
+//! ```text
+//! ovim notes.txt --headless --session demo
+//! OVIM_REMOTE_SESSION="$HOME/.cache/ovim/sessions/demo.json" \
+//!     cargo test --test remote_session_test -- --ignored --nocapture
+//! ```
+//!
+//! `OVIM_REMOTE_ENDPOINT` optionally says where to dial -- `HOST:PORT`, or a
+//! bare port on loopback. That is how the same test covers a forwarded port:
+//! the descriptor still fixes the Host header the session insists on, while
+//! the connection goes to the local end of the tunnel.
+
+use ovim::gui::{GuiBridge, GuiKeyInput, GuiSnapshot, RemoteEndpoint, RemoteTransport};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+
+fn typed(key: &str) -> GuiKeyInput {
+    GuiKeyInput {
+        key: key.to_string(),
+        shift: false,
+        control: false,
+        alt: false,
+        meta: false,
+    }
+}
+
+/// The next frame the session projects.
+async fn next_frame(updates: &mut watch::Receiver<Option<GuiSnapshot>>) -> GuiSnapshot {
+    loop {
+        tokio::time::timeout(Duration::from_secs(10), updates.changed())
+            .await
+            .expect("the session should project a frame within ten seconds")
+            .expect("the snapshot stream should stay open");
+        let frame = updates.borrow_and_update().clone();
+        if let Some(frame) = frame {
+            return frame;
+        }
+    }
+}
+
+fn line_text(frame: &GuiSnapshot, index: usize) -> String {
+    frame.lines[index]
+        .segments
+        .iter()
+        .map(|segment| segment.text.as_str())
+        .collect()
+}
+
+#[tokio::test]
+#[ignore = "needs a running headless session; see the module comment"]
+async fn keystrokes_reach_a_live_session_and_its_snapshots_come_back() {
+    let descriptor = PathBuf::from(
+        std::env::var("OVIM_REMOTE_SESSION")
+            .expect("OVIM_REMOTE_SESSION must name a session descriptor"),
+    );
+    let address = std::env::var("OVIM_REMOTE_ENDPOINT").ok();
+    let endpoint = RemoteEndpoint::from_session_file(&descriptor, address.as_deref())
+        .expect("the descriptor should describe a reachable session");
+
+    let transport = RemoteTransport::open(endpoint)
+        .await
+        .expect("the session should accept the transport");
+    let bridge = GuiBridge::new(Arc::new(transport));
+    let mut updates = bridge.subscribe();
+
+    // Subscribing is what makes an otherwise unwatched session project at all.
+    let first = next_frame(&mut updates).await;
+    println!(
+        "first frame: revision {}, mode {}, {} lines, first line {:?}",
+        first.revision,
+        first.mode,
+        first.total_lines,
+        line_text(&first, 0)
+    );
+
+    // Typed rather than pasted, so this exercises the same path a keystroke
+    // from a window takes.
+    let baseline = line_text(&first, 0);
+    for key in ["i", "r", "e", "m", "o", "t", "e", "Escape"] {
+        bridge
+            .key(typed(key))
+            .await
+            .unwrap_or_else(|error| panic!("{key} should reach the editor: {error}"));
+    }
+
+    // Compared against what the line held on arrival rather than against a
+    // fixed string: a session that has been edited before is still a session,
+    // and reconnecting to one is the point of the exercise.
+    let mut edited = next_frame(&mut updates).await;
+    while line_text(&edited, 0) == baseline {
+        edited = next_frame(&mut updates).await;
+    }
+    println!(
+        "after typing: revision {}, mode {}, first line {:?}",
+        edited.revision,
+        edited.mode,
+        line_text(&edited, 0)
+    );
+    assert!(
+        edited.revision > first.revision,
+        "revisions must advance as the buffer changes"
+    );
+    assert_eq!(
+        line_text(&edited, 0).len(),
+        baseline.len() + "remote".len(),
+        "every typed character should have landed exactly once"
+    );
+
+    // Dropping the bridge closes the stream and nothing else. The session is
+    // deliberately left running: a window closing must not end it, which is
+    // what a later reconnect depends on.
+    drop(bridge);
+}

--- a/planning/remote-editing/PLAN.md
+++ b/planning/remote-editing/PLAN.md
@@ -218,6 +218,34 @@ client, so R4 writes its own rather than extending `OvimClient`.
   `GuiReply::Path` is gone too and the command count is 32, not 31. The two
   Tauri diff commands are now pure passthroughs; the frontend was unchanged.
 
+**R4 landed; notes for R5.**
+
+- `RemoteTransport` (`ovim/src/gui/remote.rs`) owns its own two-worker Tokio
+  runtime. Every request and the snapshot stream run on it, so a `send` future
+  can be polled by whatever runtime Tauri hands it and the synchronous
+  `send_oneway` has a reactor to reach even though it runs from a plain thread.
+- `RemoteEndpoint` keeps the address dialled and the session's own port as two
+  separate fields and always sets `Host` from the latter, pinned in the
+  client's default headers. `RemoteEndpoint::from_session` takes both, plus the
+  capability, from the session descriptor, so the only thing R5 has to supply
+  is where to dial.
+- The launch surface is `ovim gui --remote-session <descriptor>
+  [--remote-endpoint HOST:PORT]`, also accepted by the `ovim-gui` binary. The
+  capability is never an argument -- it travels in the descriptor. R5 replaces
+  this pair with `--remote user@host`, which will fetch the descriptor over SSH
+  and forward the port itself; the transport underneath needs no change.
+- The stream is decoded by a small hand-written SSE decoder rather than a
+  dependency: both ends of the stream are ours and the format in use is three
+  field names and a blank line.
+- A stream that dies annotates the last frame's status line with
+  `remote::CONNECTION_LOST` and stops. That is deliberately a placeholder for
+  R6: the watch channel can only carry snapshots, so there is nowhere else for
+  a connection state to live.
+- Verified live on one machine, including through a forwarded port: a GUI
+  window driven by a headless session, and the session outliving the window.
+  `ovim/tests/remote_session_test.rs` is the ignored end-to-end test that does
+  it, driven by `OVIM_REMOTE_SESSION` and `OVIM_REMOTE_ENDPOINT`.
+
 **Test harness for R4 already exists.** R2 added `RecordingTransport` and
 `every_typed_helper_sends_the_command_variant_it_is_named_for` in
 `gui/bridge.rs`, which pins every helper to its command variant. R4

--- a/planning/remote-editing/PLAN.md
+++ b/planning/remote-editing/PLAN.md
@@ -196,6 +196,28 @@ must set `Host` explicitly to the remote port.
 (`pub fn`, `.send()` without `.await`). `RemoteTransport` needs an async
 client, so R4 writes its own rather than extending `OvimClient`.
 
+**R3 landed; notes for R4.**
+
+- The routes are `POST /v1/gui/command` (a `GuiCommand` in, a `GuiReply` out,
+  `204 No Content` for a fire-and-forget command) and `GET /v1/gui/stream`
+  (SSE, `event: snapshot`, 15s keep-alive). They live only under `/v1`, not on
+  the deprecated unversioned paths. A command that failed *in the editor*
+  still answers `200` with an `Err` reply, exactly as `LocalTransport` does,
+  so `RemoteTransport` can be a thin byte-for-byte shim.
+- Snapshot production is lazy on `watch::Sender::receiver_count()`. A session
+  with no stream subscriber never projects a `GuiSnapshot` at all. Because
+  `Sender::subscribe` marks the current value as already seen, the frame on
+  record is cleared when the last subscriber leaves; a new subscriber
+  therefore never reads a stale frame, and the publisher, seeing nothing on
+  record, projects a fresh one on its next 50ms tick.
+- `GuiCommand::Shutdown` stops the headless session. R4 must not wire it to
+  the local window closing -- that would defeat the session persistence R6 is
+  built on. Use it only for an explicit "quit the remote editor".
+- `GuiCommand::DiffWorkspace` is gone. `DiffReview { spec }` and
+  `DiffFilePatch { spec, path }` replace it and return the computed values, so
+  `GuiReply::Path` is gone too and the command count is 32, not 31. The two
+  Tauri diff commands are now pure passthroughs; the frontend was unchanged.
+
 **Test harness for R4 already exists.** R2 added `RecordingTransport` and
 `every_typed_helper_sends_the_command_variant_it_is_named_for` in
 `gui/bridge.rs`, which pins all 31 helpers to their command variants. R4

--- a/planning/remote-editing/PLAN.md
+++ b/planning/remote-editing/PLAN.md
@@ -220,6 +220,6 @@ client, so R4 writes its own rather than extending `OvimClient`.
 
 **Test harness for R4 already exists.** R2 added `RecordingTransport` and
 `every_typed_helper_sends_the_command_variant_it_is_named_for` in
-`gui/bridge.rs`, which pins all 31 helpers to their command variants. R4
+`gui/bridge.rs`, which pins every helper to its command variant. R4
 should reuse that harness to prove the remote transport is wire-equivalent to
 the local one.


### PR DESCRIPTION
Remote editing works end to end. A local `ovim-gui` can now drive an editor running in a separate headless `ovim` process, with LSP, git, grep and the rest running where the code is.

Stacked on #13 (which is stacked on #12). Bases retarget as those merge.

## What works

```
ovim doc.txt --headless --session demo          # on the remote host
ovim gui --remote-session ~/.cache/ovim/sessions/demo.json --remote-endpoint 41777
```

Verified through a port forward whose local port deliberately differs from the session's own (41777 → 34125, the `ssh -L` shape):

```
first frame:  revision 2,  mode NORMAL, 2 lines, first line "alpha"
after typing: revision 9,  mode INSERT, first line "remotealpha"
```

Reconnecting with a **new** client afterwards:

```
first frame:  revision 11, mode NORMAL, first line "remotealpha"
```

The session survived the first client disconnecting and the second picked up its state. That session persistence is the property this architecture was chosen for, and it is what the VS Code split-services model structurally cannot offer.

## R3 — server

`POST /v1/gui/command` (a `GuiCommand` → a `GuiReply`; `204` for fire-and-forget; `503` when the conversation itself is broken) and `GET /v1/gui/stream` (SSE, 15s keep-alive). Both mounted under `/v1` only, inside the existing `secure_router`, so bearer auth and the Host guard apply unchanged.

A command that fails *inside the editor* still returns `200` with an `Err` reply — the status describes the conversation, not the command — so the remote transport stays a thin shim over local semantics.

**Snapshot production is lazy.** A session with no stream subscriber never builds a `GuiSnapshot` at all, so automation-only sessions pay nothing. Laziness rides on `watch::Sender::receiver_count()` rather than a separate atomic. Because `subscribe` marks the current value as already seen, the frame on record is cleared when the last subscriber leaves — so a new subscriber can never read a stale frame, and the publisher projects a fresh one on its next tick. Measured: 200 keystrokes with nobody streaming advanced the revision by zero.

**The diff surface moved server-side.** `GuiCommand::DiffWorkspace` returned a `PathBuf` that the client then ran `native_diff::review()` on locally — fine on one machine, broken across two. It is replaced by `DiffReview { spec }` and `DiffFilePatch { spec, path }`, which return computed values from where the repository actually is. Both run on a blocking pool so the Git walk never stalls the editor loop. The two Tauri commands became passthroughs and the frontend needed no changes.

## R4 — client

`RemoteTransport` implements the `GuiTransport` trait added in #13, so `gui/app.rs` is unchanged and the local path is byte-for-byte what it was.

**The Host-header trap.** `ApiSecurity` requires `Host` to match the *server's own* port, but under `ssh -L` the dialled port differs, so an HTTP client's URL-derived Host gets a `403` that is essentially unguessable from the symptom. `RemoteEndpoint` keeps the dial address and `session_port` as separate fields with no default relationship, and pins `Host` in the client's default headers so no call site can forget it. A `403` also names the cause in its error text. Confirmed live: dialled-port Host → `403`, session-port Host → `200`.

**Token handling.** The capability is never a command-line argument — it would leak into the process table and shell history. It travels inside the session descriptor file. A file rather than an environment variable because the GUI spawns child processes that would inherit an exported variable, and `/proc/<pid>/environ` is readable by the same user.

**`Shutdown` is not wired to window close.** It stops the remote session, which would destroy the persistence above. Closing a local window leaves the remote editor running — verified by killing both GUI windows and seeing the session still report `healthy`.

SSE is decoded by a hand-written `SseDecoder` over `bytes_stream()` rather than pulling in `eventsource-stream`: both ends of the stream are ours and the format in use is three field names and a blank line. Chunk boundaries splitting an event, keep-alive comments, CRLF, multi-line `data:`, unknown fields, and two events in one chunk each have a named test. Buffering is byte-level so a multi-byte character split across chunks can't be mangled.

A dead stream rewrites the last frame's `status_message` to name the lost connection at a bumped revision, rather than freezing the window silently. That's a placeholder for proper reconnection.

## Tests

+36 tests. The strongest is `a_remote_transport_drives_a_real_session_over_a_socket` — the real router, real security layer, and a real `Editor` over a real socket on a port that is not the one it claims. `every_typed_helper_reaches_the_session_as_the_command_it_is_named_for` reuses #13's harness to pin all 32 command variants over the wire exactly as they are in-process.

`ovim/tests/remote_session_test.rs` is `#[ignore]`d and drives a live session via `OVIM_REMOTE_SESSION`; the module comment says how to run it.

## Not verified

- **No rendered GUI pixels.** Both remote *and* a local-mode control render a blank window in this environment, so it isn't caused by these changes — but the remote conversation is proven with sockets, byte counters and snapshot revisions, not with visible text. Worth a look on a normal desktop session.
- A real `ssh -L` tunnel; `socat` stood in. Nothing here measures latency over a real link.
- `send_oneway`'s blocking branch was exercised against a local editor, not a live remote shutdown.

## Known follow-ups (recorded in the plan)

Reconnection, predictive local echo (required above ~40ms RTT), clipboard bridging, `AttachImages` drag-drop path handling, and `:openwin` host awareness.