### PR TITLE
fix(remote): order remote commands, and bridge the clipboard

### DIFF
--- a/ovim-core/src/editor/mod.rs
+++ b/ovim-core/src/editor/mod.rs
@@ -146,7 +146,7 @@ pub use performance::{PerformanceMetrics, MAX_LATENCY_SAMPLES};
 pub use picker::{Picker, PickerAction, PickerField, PickerMode, PickerResult};
 pub use picker_state::PickerState;
 pub use quickfix::{LocationList, QuickfixEntry, QuickfixEntryType, QuickfixList};
-pub use register::{RegisterManager, RegisterType};
+pub use register::{read_system_clipboard, write_system_clipboard, RegisterManager, RegisterType};
 pub use render_cache::RenderCache;
 pub use search::Search;
 pub use search_context::{SearchContext, VisualSearchState};

--- a/ovim-core/src/editor/register.rs
+++ b/ovim-core/src/editor/register.rs
@@ -29,6 +29,26 @@ fn with_clipboard<T>(
     f(cb).ok()
 }
 
+/// Put `text` on the system clipboard of the machine this process runs on.
+///
+/// Free-standing because a process can need the clipboard without owning an
+/// editor: the graphical frontend may be driving an editor on another host,
+/// where `RegisterManager`'s own provider reaches the *wrong* machine's
+/// clipboard. Sharing `with_clipboard` keeps both callers behind the one mutex
+/// the platform requires.
+pub fn write_system_clipboard(text: &str) -> bool {
+    with_clipboard(|clipboard| clipboard.set_text(text.to_string())).is_some()
+}
+
+/// Read the system clipboard of the machine this process runs on.
+///
+/// `None` when there is no clipboard to read -- over SSH, headless, or on a
+/// Wayland session without a seat. See [`write_system_clipboard`] for why this
+/// exists beside [`RegisterManager`].
+pub fn read_system_clipboard() -> Option<String> {
+    with_clipboard(|clipboard| clipboard.get_text())
+}
+
 /// System clipboard provider.
 ///
 /// Reads/writes go through the process-wide `CLIPBOARD` mutex.
@@ -38,18 +58,28 @@ fn with_clipboard<T>(
 struct ClipboardProvider {
     /// Fallback when the system clipboard is unavailable.
     cached: String,
+    /// How many times this editor has written the clipboard.
+    ///
+    /// A frontend on another machine mirrors those writes onto its own
+    /// clipboard, and it needs to know that one happened without being handed
+    /// the text on every frame. Counting them is the whole signal: it rises
+    /// only for a write the editor itself made, so a clipboard changed by some
+    /// other program on this host is not mistaken for something to mirror.
+    generation: u64,
 }
 
 impl ClipboardProvider {
     fn new() -> Self {
         Self {
             cached: String::new(),
+            generation: 0,
         }
     }
 
     fn write(&mut self, text: String) {
         with_clipboard(|cb| cb.set_text(text.clone()));
         self.cached = text;
+        self.generation = self.generation.wrapping_add(1);
     }
 
     fn read(&self) -> String {
@@ -368,6 +398,25 @@ impl RegisterManager {
     /// Gets the clipboard content (reads from system clipboard with fallback to cache)
     pub fn get_clipboard(&self) -> String {
         self.clipboard.read()
+    }
+
+    /// How many times this editor has written the system clipboard.
+    ///
+    /// The signal a frontend on another machine watches so it can mirror those
+    /// writes onto its own clipboard. It rises only for a write this editor
+    /// made, never for one some other program on this host made.
+    pub fn clipboard_generation(&self) -> u64 {
+        self.clipboard.generation
+    }
+
+    /// The text this editor last put on the system clipboard.
+    ///
+    /// Deliberately not [`RegisterManager::get_clipboard`], which reads back
+    /// whatever the host's clipboard holds now. A remote frontend is mirroring
+    /// what *the editor* copied, and on a headless host the two differ --
+    /// there is often no clipboard there to read at all.
+    pub fn last_clipboard_write(&self) -> &str {
+        &self.clipboard.cached
     }
 
     /// Lists all non-empty registers as (name, content) pairs

--- a/ovim/src/gui/app.rs
+++ b/ovim/src/gui/app.rs
@@ -628,6 +628,19 @@ pub fn run(file: Option<FileArg>, resume: bool, remote: Option<RemoteLaunch>) ->
                     .set_title("Ovim")
                     .context("Failed to set the GUI window title")?;
                 let drop_bridge = app.state::<GuiBridge>().inner().clone();
+                // A yank on the editor's host reaches this machine's clipboard
+                // by following the frames; this machine's clipboard reaches the
+                // editor when the window is activated, which is the one moment
+                // between "copied in a browser" and "pressed `p`" that this
+                // process gets to see. See `gui::clipboard` for the policy.
+                let focus_clipboard = super::clipboard::start(
+                    &drop_bridge,
+                    Arc::new(super::clipboard::SystemClipboard),
+                )
+                .map(|(handle, follow)| {
+                    tauri::async_runtime::spawn(follow);
+                    handle
+                });
                 let close_window = window.clone();
                 let close_gate = setup_exit_gate.clone();
                 window.on_window_event(move |event| match event {
@@ -643,6 +656,13 @@ pub fn run(file: Option<FileArg>, resume: bool, remote: Option<RemoteLaunch>) ->
                         tauri::async_runtime::spawn(async move {
                             let _ = bridge.attach_images(paths).await;
                         });
+                    }
+                    WindowEvent::Focused(true) => {
+                        if let Some(clipboard) = focus_clipboard.clone() {
+                            tauri::async_runtime::spawn(async move {
+                                clipboard.push_latest().await;
+                            });
+                        }
                     }
                     _ => {}
                 });

--- a/ovim/src/gui/bridge.rs
+++ b/ovim/src/gui/bridge.rs
@@ -7,7 +7,7 @@
 //! without any of the typed helpers on `GuiBridge` changing shape.
 
 use super::protocol::{
-    GuiCommand, GuiKeyInput, GuiReply, GuiReplyKind, GuiSnapshot, GuiVectorSource,
+    GuiClipboardText, GuiCommand, GuiKeyInput, GuiReply, GuiReplyKind, GuiSnapshot, GuiVectorSource,
 };
 use super::reconnect::GuiConnection;
 use crate::cli::FileArg;
@@ -172,6 +172,13 @@ pub enum GuiRequest {
         index: usize,
         reply: oneshot::Sender<Result<(), String>>,
     },
+    ReadClipboard {
+        reply: oneshot::Sender<Result<GuiClipboardText, String>>,
+    },
+    WriteClipboard {
+        text: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
     Shutdown,
 }
 
@@ -187,6 +194,7 @@ pub enum GuiReplySender {
     VectorSource(oneshot::Sender<Result<GuiVectorSource, String>>),
     DiffReview(oneshot::Sender<Result<DiffReview, String>>),
     DiffPatch(oneshot::Sender<Result<String, String>>),
+    Clipboard(oneshot::Sender<Result<GuiClipboardText, String>>),
 }
 
 impl GuiReplySender {
@@ -227,6 +235,13 @@ impl GuiReplySender {
                     GuiReplyReceiver::DiffPatch(rx),
                 )
             }
+            GuiReplyKind::Clipboard => {
+                let (tx, rx) = oneshot::channel();
+                (
+                    GuiReplySender::Clipboard(tx),
+                    GuiReplyReceiver::Clipboard(rx),
+                )
+            }
         }
     }
 
@@ -238,6 +253,7 @@ impl GuiReplySender {
             GuiReplySender::VectorSource(_) => GuiReplyKind::VectorSource,
             GuiReplySender::DiffReview(_) => GuiReplyKind::DiffReview,
             GuiReplySender::DiffPatch(_) => GuiReplyKind::DiffPatch,
+            GuiReplySender::Clipboard(_) => GuiReplyKind::Clipboard,
         }
     }
 }
@@ -250,6 +266,7 @@ pub enum GuiReplyReceiver {
     VectorSource(oneshot::Receiver<Result<GuiVectorSource, String>>),
     DiffReview(oneshot::Receiver<Result<DiffReview, String>>),
     DiffPatch(oneshot::Receiver<Result<String, String>>),
+    Clipboard(oneshot::Receiver<Result<GuiClipboardText, String>>),
 }
 
 impl GuiReplyReceiver {
@@ -273,6 +290,9 @@ impl GuiReplyReceiver {
                 rx.await.map_err(|_| REPLY_CLOSED.to_string())?,
             )),
             GuiReplyReceiver::DiffPatch(rx) => Some(GuiReply::DiffPatch(
+                rx.await.map_err(|_| REPLY_CLOSED.to_string())?,
+            )),
+            GuiReplyReceiver::Clipboard(rx) => Some(GuiReply::Clipboard(
                 rx.await.map_err(|_| REPLY_CLOSED.to_string())?,
             )),
         })
@@ -434,6 +454,12 @@ impl GuiRequest {
             }
             (GuiCommand::SelectDebugFrame { index }, GuiReplySender::Unit(reply)) => {
                 GuiRequest::SelectDebugFrame { index, reply }
+            }
+            (GuiCommand::ReadClipboard, GuiReplySender::Clipboard(reply)) => {
+                GuiRequest::ReadClipboard { reply }
+            }
+            (GuiCommand::WriteClipboard { text }, GuiReplySender::Unit(reply)) => {
+                GuiRequest::WriteClipboard { text, reply }
             }
             (GuiCommand::Shutdown, GuiReplySender::None) => GuiRequest::Shutdown,
             (command, reply) => {
@@ -621,6 +647,13 @@ impl GuiRequest {
             ),
             GuiRequest::SelectDebugFrame { index, reply } => (
                 GuiCommand::SelectDebugFrame { index },
+                GuiReplySender::Unit(reply),
+            ),
+            GuiRequest::ReadClipboard { reply } => {
+                (GuiCommand::ReadClipboard, GuiReplySender::Clipboard(reply))
+            }
+            GuiRequest::WriteClipboard { text, reply } => (
+                GuiCommand::WriteClipboard { text },
                 GuiReplySender::Unit(reply),
             ),
             GuiRequest::Shutdown => (GuiCommand::Shutdown, GuiReplySender::None),
@@ -1052,6 +1085,22 @@ impl GuiBridge {
         self.unit(GuiCommand::SelectChatAgent { agent_id }).await
     }
 
+    /// The text the editor last put on its own host's system clipboard.
+    ///
+    /// Only worth asking when [`GuiSnapshot::clipboard`]'s generation has
+    /// moved; see [`crate::gui::clipboard`] for the policy around it.
+    pub async fn read_clipboard(&self) -> Result<GuiClipboardText, String> {
+        match self.transport.send(GuiCommand::ReadClipboard).await? {
+            Some(GuiReply::Clipboard(result)) => result,
+            other => Err(mismatched_reply(GuiReplyKind::Clipboard, other.as_ref())),
+        }
+    }
+
+    /// Put this machine's clipboard into the editor's `+` register.
+    pub async fn write_clipboard(&self, text: String) -> Result<(), String> {
+        self.unit(GuiCommand::WriteClipboard { text }).await
+    }
+
     /// Ask the editor to stop, from a context that cannot await.
     ///
     /// The editor is on its way out either way, so a transport that has
@@ -1178,6 +1227,12 @@ pub(crate) mod tests {
                     GuiReplySender::DiffReview(tx) => {
                         let _ = tx.send(Ok(protocol::sample_diff_review()));
                     }
+                    GuiReplySender::Clipboard(tx) => {
+                        let _ = tx.send(Ok(GuiClipboardText {
+                            generation: 1,
+                            text: "yanked".to_string(),
+                        }));
+                    }
                     GuiReplySender::DiffPatch(tx) => {
                         let _ = tx.send(Ok("@@ -1 +1 @@\n-old\n+new\n".to_string()));
                     }
@@ -1262,23 +1317,43 @@ pub(crate) mod tests {
     ///
     /// This is what catches a typed helper wired to the wrong variant, and it
     /// is the harness a remote transport will be tested against.
-    struct RecordingTransport {
+    pub(crate) struct RecordingTransport {
         received: Mutex<Vec<GuiCommand>>,
         snapshot: GuiSnapshot,
         updates: watch::Sender<Option<GuiSnapshot>>,
+        /// An answer for a command whose canned reply is not specific enough.
+        #[allow(clippy::type_complexity)]
+        scripted: Option<Box<dyn Fn(&GuiCommand) -> Option<GuiReply> + Send + Sync>>,
+        remote: bool,
     }
 
     impl RecordingTransport {
-        fn new() -> Arc<Self> {
+        pub(crate) fn new() -> Arc<Self> {
             let (updates, _) = watch::channel(None);
             Arc::new(Self {
                 received: Mutex::new(Vec::new()),
                 snapshot: super::super::snapshot(&Editor::with_content("fn main() {}\n"), 1, 0),
                 updates,
+                scripted: None,
+                remote: false,
             })
         }
 
-        fn received(&self) -> Vec<GuiCommand> {
+        /// A transport that reports itself remote and scripts some answers.
+        pub(crate) fn remote_answering(
+            answer: impl Fn(&GuiCommand) -> Option<GuiReply> + Send + Sync + 'static,
+        ) -> Self {
+            let (updates, _) = watch::channel(None);
+            Self {
+                received: Mutex::new(Vec::new()),
+                snapshot: super::super::snapshot(&Editor::with_content("fn main() {}\n"), 1, 0),
+                updates,
+                scripted: Some(Box::new(answer)),
+                remote: true,
+            }
+        }
+
+        pub(crate) fn received(&self) -> Vec<GuiCommand> {
             self.received.lock().unwrap().clone()
         }
     }
@@ -1289,9 +1364,13 @@ pub(crate) mod tests {
             command: GuiCommand,
         ) -> GuiTransportFuture<'_, Result<Option<GuiReply>, String>> {
             let kind = command.reply_kind();
+            let scripted = self.scripted.as_ref().and_then(|answer| answer(&command));
             self.received.lock().unwrap().push(command);
             let snapshot = self.snapshot.clone();
             Box::pin(async move {
+                if let Some(scripted) = scripted {
+                    return Ok(Some(scripted));
+                }
                 Ok(match kind {
                     GuiReplyKind::None => None,
                     GuiReplyKind::Unit => Some(GuiReply::Unit(Ok(()))),
@@ -1308,6 +1387,12 @@ pub(crate) mod tests {
                     GuiReplyKind::DiffPatch => Some(GuiReply::DiffPatch(Ok(
                         "@@ -1 +1 @@\n-old\n+new\n".to_string(),
                     ))),
+                    GuiReplyKind::Clipboard => {
+                        Some(GuiReply::Clipboard(Ok(protocol::GuiClipboardText {
+                            generation: 1,
+                            text: "yanked".to_string(),
+                        })))
+                    }
                 })
             })
         }
@@ -1319,6 +1404,10 @@ pub(crate) mod tests {
 
         fn subscribe(&self) -> watch::Receiver<Option<GuiSnapshot>> {
             self.updates.subscribe()
+        }
+
+        fn is_remote(&self) -> bool {
+            self.remote
         }
     }
 
@@ -1437,6 +1526,11 @@ pub(crate) mod tests {
             .unwrap();
         bridge.select_lsp(9, false).await.unwrap();
         bridge.select_debug_frame(2).await.unwrap();
+        bridge.read_clipboard().await.unwrap();
+        bridge
+            .write_clipboard("clipboard text".to_string())
+            .await
+            .unwrap();
         bridge.shutdown();
     }
 
@@ -1451,7 +1545,7 @@ pub(crate) mod tests {
         exercise_every_helper(&bridge).await;
 
         let expected = every_command_once();
-        assert_eq!(expected.len(), 32, "the sweep should reach every variant");
+        assert_eq!(expected.len(), 34, "the sweep should reach every variant");
         assert_eq!(transport.received(), expected);
     }
 

--- a/ovim/src/gui/clipboard.rs
+++ b/ovim/src/gui/clipboard.rs
@@ -1,0 +1,505 @@
+//! Bridging two machines' clipboards.
+//!
+//! A yank in a remote editor fills a register on the *editor's* host. The
+//! clipboard the user pastes into lives on the laptop running the window, and
+//! on a headless remote there is usually no clipboard at all -- `arboard` finds
+//! no display, `ClipboardProvider` falls back to an in-process cache, and the
+//! yank goes nowhere a browser could reach. This module carries it across, and
+//! carries the laptop's clipboard the other way so `p` in a remote editor
+//! pastes what the user copied here.
+//!
+//! **The policy is Ovim's existing one, observed rather than reinvented.**
+//! Nothing here decides when a yank belongs on the system clipboard; the editor
+//! already decides that from `set clipboard=`, and the only new question is
+//! *which machine's* clipboard it means.
+//!
+//! * **Editor to frontend.** [`GuiClipboard::generation`] counts the writes the
+//!   editor made to its own `+` register. It rises exactly when a local Ovim
+//!   would have put the text on the user's clipboard -- a yank or delete under
+//!   `unnamedplus`, or an explicit `"+y` whatever the option says -- so
+//!   mirroring every rise reproduces the local behaviour and adds no case to
+//!   it. A user with `set clipboard=` sees nothing arrive from a plain `y`,
+//!   because the editor never wrote its own clipboard either.
+//! * **Frontend to editor.** Gated on [`GuiClipboard::shared`], the same
+//!   option read as a boolean. This is the direction that sends the user's
+//!   clipboard to another host, and `unnamedplus` is the declaration that
+//!   makes it defensible: the user has said their system clipboard *is* the
+//!   editor's default register. Somebody who has not said that gets nothing.
+//!
+//! Both directions run in this process rather than in the webview. The client
+//! already links `ovim-core`, so it has the same `arboard` the editor uses --
+//! which means identical semantics to a local Ovim, no clipboard-permission
+//! prompt, no dependence on a DOM gesture, and no clipboard content passing
+//! through the webview or its IPC at all.
+
+use super::protocol::GuiSnapshot;
+use super::GuiBridge;
+use ovim_core::editor::Editor;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// The most text either direction will carry.
+///
+/// A clipboard exists to be pasted somewhere by a person. 1 MiB is on the
+/// order of fifteen thousand lines of source -- far past anything anyone pastes
+/// into a browser or a chat window by hand -- and it is about a second on the
+/// kind of uplink a laptop has, where the 20 MiB the image path allows would be
+/// twenty. The asymmetry with images is deliberate: a pasted screenshot has no
+/// smaller form and no other way to travel, whereas an oversized yank is still
+/// sitting in the remote register with better options than the clipboard
+/// (`:w` it, or pipe it). Refusing loudly beats spending a minute of the link
+/// on something the user will not paste anywhere.
+pub const MAX_CLIPBOARD_BYTES: usize = 1024 * 1024;
+
+/// What the editor would hand a frontend asking for its clipboard.
+///
+/// Reads what the editor last *wrote*, not what its host's clipboard holds
+/// now: the frontend is mirroring this editor, and on a headless host there is
+/// frequently nothing to read back.
+pub fn clipboard_text(editor: &Editor) -> Result<super::GuiClipboardText, String> {
+    let text = editor.registers().last_clipboard_write();
+    within_limit(text)?;
+    Ok(super::GuiClipboardText {
+        generation: editor.registers().clipboard_generation(),
+        text: text.to_string(),
+    })
+}
+
+/// Refuse text the bridge will not carry, saying how far past the line it is.
+pub(super) fn within_limit(text: &str) -> Result<(), String> {
+    if text.len() <= MAX_CLIPBOARD_BYTES {
+        return Ok(());
+    }
+    Err(format!(
+        "The clipboard is {} bytes, past the {} MiB clipboard bridging limit",
+        text.len(),
+        MAX_CLIPBOARD_BYTES / (1024 * 1024)
+    ))
+}
+
+/// The system clipboard of the machine the *frontend* runs on.
+///
+/// A trait only so the policy above can be tested without a display; the one
+/// implementation that ships is [`SystemClipboard`].
+pub trait LocalClipboard: Send + Sync {
+    fn read(&self) -> Option<String>;
+    fn write(&self, text: &str);
+}
+
+/// The real clipboard, through the same `arboard` handle the editor uses.
+pub struct SystemClipboard;
+
+impl LocalClipboard for SystemClipboard {
+    fn read(&self) -> Option<String> {
+        ovim_core::editor::read_system_clipboard()
+    }
+
+    fn write(&self, text: &str) {
+        ovim_core::editor::write_system_clipboard(text);
+    }
+}
+
+/// Keeps this machine's clipboard and a remote editor's `+` register in step.
+pub struct ClipboardBridge {
+    bridge: GuiBridge,
+    local: Arc<dyn LocalClipboard>,
+    /// The editor write generation already mirrored here.
+    ///
+    /// `None` until the first frame: adopting whatever the session had on
+    /// arrival would mean a reconnect replaying an old yank over a clipboard
+    /// the user has since filled from somewhere else.
+    mirrored: Mutex<Option<u64>>,
+    /// The text last pushed to the editor, so an unchanged clipboard is not
+    /// sent again on every window activation.
+    pushed: Mutex<Option<String>>,
+}
+
+impl ClipboardBridge {
+    pub fn new(bridge: GuiBridge, local: Arc<dyn LocalClipboard>) -> Self {
+        Self {
+            bridge,
+            local,
+            mirrored: Mutex::new(None),
+            pushed: Mutex::new(None),
+        }
+    }
+
+    /// Copy a yank the editor just made onto this machine's clipboard.
+    ///
+    /// Called for every frame and does nothing for almost all of them: the
+    /// generation only moves when the editor wrote its own clipboard.
+    pub async fn mirror(&self, frame: &GuiSnapshot) {
+        let generation = frame.clipboard.generation;
+        {
+            let mirrored = self.mirrored.lock().expect("the lock is never poisoned");
+            // Compared for inequality rather than for being greater: a session
+            // that was replaced starts counting from one again, and a client
+            // that only ever moved forwards would then stop mirroring for the
+            // rest of its life.
+            if *mirrored == Some(generation) {
+                return;
+            }
+            if mirrored.is_none() && generation == 0 {
+                // Nothing has been yanked yet, so there is nothing to adopt.
+                drop(mirrored);
+                self.remember(generation);
+                return;
+            }
+        }
+        let fetched = match self.bridge.read_clipboard().await {
+            Ok(fetched) => fetched,
+            Err(error) => {
+                // A refusal is either the size limit or a link that has just
+                // gone; both are worth a line in the log and neither is worth
+                // retrying, because the next frame asks again anyway.
+                ovim_core::log_warn!("gui", "Could not mirror the remote clipboard: {}", error);
+                return;
+            }
+        };
+        // The generation the answer carried, not the one the frame did: a
+        // second yank between the two would otherwise be recorded as mirrored
+        // when it was the first one that arrived.
+        self.remember(fetched.generation);
+        // Skip a write that would change nothing. This is what keeps the two
+        // directions from chasing each other -- a push into the editor's `+`
+        // register raises its generation, and the mirror that follows finds
+        // the text already here.
+        if self.local.read().as_deref() == Some(fetched.text.as_str()) {
+            return;
+        }
+        self.local.write(&fetched.text);
+    }
+
+    /// Send this machine's clipboard to the editor's `+` register.
+    ///
+    /// Called when the window is activated, which is the one moment between
+    /// "copied something in a browser" and "pressed `p` in the editor" that
+    /// this process can see. `p` cannot ask for it at the time -- the snapshot
+    /// stream is the only channel running the other way and it carries frames,
+    /// not questions -- so the sync point is the focus event instead.
+    pub async fn push(&self, frame: &GuiSnapshot) {
+        if !frame.clipboard.shared {
+            // `set clipboard=` means the user did not ask for their system
+            // clipboard to be the editor's register. Moving it to another host
+            // uninvited would be a far larger step than doing it locally.
+            return;
+        }
+        let Some(text) = self.local.read() else {
+            return;
+        };
+        if text.len() > MAX_CLIPBOARD_BYTES {
+            ovim_core::log_warn!(
+                "gui",
+                "The local clipboard is {} bytes, past the clipboard bridging limit",
+                text.len()
+            );
+            return;
+        }
+        {
+            let mut pushed = self.pushed.lock().expect("the lock is never poisoned");
+            if pushed.as_deref() == Some(text.as_str()) {
+                return;
+            }
+            *pushed = Some(text.clone());
+        }
+        if let Err(error) = self.bridge.write_clipboard(text).await {
+            // Not queued for a retry. A link that is down drops input rather
+            // than replaying it, and a clipboard is input: the next activation
+            // sends whatever is on the clipboard then, which is the value the
+            // user would expect anyway.
+            self.pushed
+                .lock()
+                .expect("the lock is never poisoned")
+                .take();
+            ovim_core::log_warn!(
+                "gui",
+                "Could not send the clipboard to the editor: {}",
+                error
+            );
+        }
+    }
+
+    /// [`ClipboardBridge::push`], against whatever frame is current.
+    ///
+    /// The window's activation handler has no frame in hand, and the newest
+    /// one is always a `borrow` away.
+    pub async fn push_latest(&self) {
+        let frame = self.bridge.subscribe().borrow().clone();
+        if let Some(frame) = frame {
+            self.push(&frame).await;
+        }
+    }
+
+    fn remember(&self, generation: u64) {
+        *self.mirrored.lock().expect("the lock is never poisoned") = Some(generation);
+    }
+}
+
+/// A bridge, and the loop that follows the editor's frames for it.
+///
+/// `None` for an in-process editor, which needs no bridge at all: it writes the
+/// very clipboard this process would write, through the same `arboard` handle,
+/// and a second writer could only get in its way.
+///
+/// The loop is handed back rather than spawned here so the caller can put it on
+/// whatever runtime it has -- the shell's `setup` hook has no ambient one.
+pub fn start(
+    bridge: &GuiBridge,
+    local: Arc<dyn LocalClipboard>,
+) -> Option<(
+    Arc<ClipboardBridge>,
+    impl std::future::Future<Output = ()> + Send + 'static,
+)> {
+    if !bridge.is_remote() {
+        return None;
+    }
+    let clipboard = Arc::new(ClipboardBridge::new(bridge.clone(), local));
+    let mut frames = bridge.subscribe();
+    let following = Arc::clone(&clipboard);
+    let follow = async move {
+        while frames.changed().await.is_ok() {
+            let frame = frames.borrow_and_update().clone();
+            if let Some(frame) = frame {
+                following.mirror(&frame).await;
+            }
+        }
+    };
+    Some((clipboard, follow))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::bridge::tests::RecordingTransport;
+    use crate::gui::protocol::{GuiClipboard, GuiClipboardText, GuiCommand, GuiReply};
+    use std::sync::Mutex as StdMutex;
+
+    /// A clipboard in memory, standing in for one on a screen.
+    #[derive(Default)]
+    struct FakeClipboard {
+        held: StdMutex<Option<String>>,
+        writes: StdMutex<u32>,
+    }
+
+    impl FakeClipboard {
+        fn holding(text: &str) -> Self {
+            Self {
+                held: StdMutex::new(Some(text.to_string())),
+                writes: StdMutex::new(0),
+            }
+        }
+
+        fn contents(&self) -> Option<String> {
+            self.held.lock().unwrap().clone()
+        }
+
+        fn writes(&self) -> u32 {
+            *self.writes.lock().unwrap()
+        }
+    }
+
+    impl LocalClipboard for FakeClipboard {
+        fn read(&self) -> Option<String> {
+            self.held.lock().unwrap().clone()
+        }
+
+        fn write(&self, text: &str) {
+            *self.held.lock().unwrap() = Some(text.to_string());
+            *self.writes.lock().unwrap() += 1;
+        }
+    }
+
+    /// A frame carrying nothing but a clipboard policy.
+    fn frame(shared: bool, generation: u64) -> GuiSnapshot {
+        let mut snapshot = super::super::snapshot(&Editor::with_content("fn main() {}\n"), 1, 0);
+        snapshot.clipboard = GuiClipboard { shared, generation };
+        snapshot
+    }
+
+    /// A bridge whose editor answers `ReadClipboard` with `text`.
+    fn bridged(text: &str, generation: u64) -> (GuiBridge, Arc<RecordingTransport>) {
+        let answer = GuiClipboardText {
+            generation,
+            text: text.to_string(),
+        };
+        let transport = Arc::new(RecordingTransport::remote_answering(move |command| {
+            matches!(command, GuiCommand::ReadClipboard)
+                .then(|| GuiReply::Clipboard(Ok(answer.clone())))
+        }));
+        (GuiBridge::new(transport.clone()), transport)
+    }
+
+    #[tokio::test]
+    async fn a_yank_on_the_editor_reaches_this_machine_s_clipboard() {
+        let local = Arc::new(FakeClipboard::default());
+        let (bridge, _transport) = bridged("yanked line\n", 1);
+        let clipboard = ClipboardBridge::new(bridge, local.clone());
+
+        clipboard.mirror(&frame(true, 1)).await;
+
+        assert_eq!(local.contents().as_deref(), Some("yanked line\n"));
+    }
+
+    #[tokio::test]
+    async fn a_frame_that_yanked_nothing_new_costs_no_round_trip() {
+        // Every frame passes through here, so the common case has to be free.
+        let local = Arc::new(FakeClipboard::default());
+        let (bridge, transport) = bridged("yanked line\n", 1);
+        let clipboard = ClipboardBridge::new(bridge, local.clone());
+
+        clipboard.mirror(&frame(true, 1)).await;
+        for _ in 0..20 {
+            clipboard.mirror(&frame(true, 1)).await;
+        }
+
+        assert_eq!(
+            transport
+                .received()
+                .iter()
+                .filter(|command| matches!(command, GuiCommand::ReadClipboard))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_session_that_started_counting_again_is_still_mirrored() {
+        // A replaced session's generation restarts at one, so a client that
+        // only ever accepted a higher number would go quiet for good -- the
+        // same trap `Link::publish` guards the revision against.
+        let local = Arc::new(FakeClipboard::default());
+        let (bridge, _transport) = bridged("after the restart", 1);
+        let clipboard = ClipboardBridge::new(bridge, local.clone());
+        clipboard.remember(9);
+
+        clipboard.mirror(&frame(true, 1)).await;
+
+        assert_eq!(local.contents().as_deref(), Some("after the restart"));
+    }
+
+    #[tokio::test]
+    async fn a_clipboard_that_already_holds_the_text_is_left_alone() {
+        // Pushing this machine's clipboard raises the editor's generation, so
+        // the mirror that follows must recognise its own text rather than
+        // writing it back and disturbing a clipboard manager for nothing.
+        let local = Arc::new(FakeClipboard::holding("already here"));
+        let (bridge, _transport) = bridged("already here", 4);
+        let clipboard = ClipboardBridge::new(bridge, local.clone());
+
+        clipboard.mirror(&frame(true, 4)).await;
+
+        assert_eq!(local.writes(), 0);
+    }
+
+    #[tokio::test]
+    async fn nothing_is_mirrored_from_a_session_that_has_never_yanked() {
+        let local = Arc::new(FakeClipboard::default());
+        let (bridge, transport) = bridged("", 0);
+        let clipboard = ClipboardBridge::new(bridge, local.clone());
+
+        clipboard.mirror(&frame(true, 0)).await;
+
+        assert!(transport.received().is_empty());
+        assert_eq!(local.contents(), None);
+    }
+
+    #[tokio::test]
+    async fn this_machine_s_clipboard_reaches_the_editor_when_the_option_asks_for_it() {
+        let local = Arc::new(FakeClipboard::holding("copied in a browser"));
+        let (bridge, transport) = bridged("", 0);
+        let clipboard = ClipboardBridge::new(bridge, local);
+
+        clipboard.push(&frame(true, 0)).await;
+
+        assert_eq!(
+            transport.received(),
+            vec![GuiCommand::WriteClipboard {
+                text: "copied in a browser".to_string()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_user_who_did_not_opt_in_locally_does_not_opt_in_by_going_remote() {
+        // `set clipboard=` is a decision about the system clipboard, and the
+        // editor being on another host does not reopen it.
+        let local = Arc::new(FakeClipboard::holding("a password, for all this knows"));
+        let (bridge, transport) = bridged("", 0);
+        let clipboard = ClipboardBridge::new(bridge, local);
+
+        clipboard.push(&frame(false, 0)).await;
+
+        assert!(transport.received().is_empty());
+    }
+
+    #[tokio::test]
+    async fn an_unchanged_clipboard_is_not_sent_again_on_every_activation() {
+        let local = Arc::new(FakeClipboard::holding("copied once"));
+        let (bridge, transport) = bridged("", 0);
+        let clipboard = ClipboardBridge::new(bridge, local);
+
+        for _ in 0..5 {
+            clipboard.push(&frame(true, 0)).await;
+        }
+
+        assert_eq!(transport.received().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_clipboard_too_large_to_carry_is_refused_rather_than_sent() {
+        let oversized = "x".repeat(MAX_CLIPBOARD_BYTES + 1);
+        let local = Arc::new(FakeClipboard::holding(&oversized));
+        let (bridge, transport) = bridged("", 0);
+        let clipboard = ClipboardBridge::new(bridge, local);
+
+        clipboard.push(&frame(true, 0)).await;
+
+        assert!(transport.received().is_empty());
+    }
+
+    #[test]
+    fn an_editor_running_in_this_process_gets_no_bridge_at_all() {
+        // It writes the very clipboard this process would write, through the
+        // same `arboard` handle. A second writer could only get in its way.
+        let bridge = GuiBridge::new(RecordingTransport::new());
+
+        assert!(start(&bridge, Arc::new(FakeClipboard::default())).is_none());
+    }
+
+    #[tokio::test]
+    async fn an_editor_on_another_host_is_followed_without_anyone_asking() {
+        let (bridge, _transport) = bridged("yanked line\n", 1);
+
+        let (clipboard, _follow) = start(&bridge, Arc::new(FakeClipboard::default()))
+            .expect("a remote editor needs the bridge");
+
+        // The handle is what the window's activation handler pushes through.
+        clipboard.push_latest().await;
+    }
+
+    #[test]
+    fn a_yank_past_the_limit_is_refused_where_the_text_is() {
+        // The bound has to hold on the editor's side too: a client cannot
+        // decline a payload it has already been sent. Checked here rather than
+        // through a register, because seeding one would put a megabyte on the
+        // machine's real clipboard.
+        assert!(within_limit(&"y".repeat(MAX_CLIPBOARD_BYTES)).is_ok());
+
+        let error = within_limit(&"y".repeat(MAX_CLIPBOARD_BYTES + 1)).unwrap_err();
+
+        assert!(error.contains("limit"), "{error}");
+    }
+
+    #[test]
+    fn what_an_editor_hands_over_is_what_it_wrote_not_what_its_host_holds() {
+        // On a headless host `get_clipboard` reads back nothing at all, so
+        // reading the provider's own record is the only way the yank survives.
+        let mut editor = Editor::with_content("fn main() {}\n");
+        editor.registers_mut().set_clipboard("yanked".to_string());
+
+        let handed = clipboard_text(&editor).unwrap();
+
+        assert_eq!(handed.text, "yanked");
+        assert_eq!(handed.generation, 1);
+    }
+}

--- a/ovim/src/gui/mod.rs
+++ b/ovim/src/gui/mod.rs
@@ -16,6 +16,7 @@ pub mod app;
 pub mod bridge;
 #[cfg(feature = "gui")]
 pub mod browser;
+pub mod clipboard;
 mod echo;
 #[cfg(feature = "gui")]
 mod menu;
@@ -37,13 +38,13 @@ pub use bridge::{
 };
 pub use protocol::{
     GuiAgentOption, GuiAiChat, GuiAiProfileOption, GuiChatMessage, GuiChatSetup,
-    GuiChatSetupAction, GuiCodeAttachment, GuiCodeExplanation, GuiCodeExplanationDiscussion,
-    GuiCodeExplanationPage, GuiCommand, GuiCompletion, GuiCompletionItem, GuiCursor, GuiDebugFrame,
-    GuiDebugPanel, GuiDiagnostics, GuiFileTree, GuiFileTreeItem, GuiGitChanges, GuiHover,
-    GuiKeyInput, GuiLayoutNode, GuiLine, GuiLspEntry, GuiLspManager, GuiPane, GuiPicker,
-    GuiPickerItem, GuiProblem, GuiProblemList, GuiPrompt, GuiQueuedChatInput, GuiReply,
-    GuiReplyKind, GuiSegment, GuiSnapshot, GuiTab, GuiTestFailure, GuiTestPanel, GuiTheme,
-    GuiVectorSource, SNAPSHOT_EVENT,
+    GuiChatSetupAction, GuiClipboard, GuiClipboardText, GuiCodeAttachment, GuiCodeExplanation,
+    GuiCodeExplanationDiscussion, GuiCodeExplanationPage, GuiCommand, GuiCompletion,
+    GuiCompletionItem, GuiCursor, GuiDebugFrame, GuiDebugPanel, GuiDiagnostics, GuiFileTree,
+    GuiFileTreeItem, GuiGitChanges, GuiHover, GuiKeyInput, GuiLayoutNode, GuiLine, GuiLspEntry,
+    GuiLspManager, GuiPane, GuiPicker, GuiPickerItem, GuiProblem, GuiProblemList, GuiPrompt,
+    GuiQueuedChatInput, GuiReply, GuiReplyKind, GuiSegment, GuiSnapshot, GuiTab, GuiTestFailure,
+    GuiTestPanel, GuiTheme, GuiVectorSource, SNAPSHOT_EVENT,
 };
 pub use reconnect::{ConnectionLoss, GuiConnection};
 pub use remote::{RemoteEndpoint, RemoteTransport};
@@ -61,6 +62,7 @@ use crate::mode::Mode;
 use crate::syntax::{HighlightGroup, UiGroup};
 use crate::unicode::GraphemeCol;
 use anyhow::{Context, Result};
+use clipboard::clipboard_text;
 use std::path::Path;
 use std::sync::mpsc as std_mpsc;
 use std::time::{Duration, Instant};
@@ -944,6 +946,23 @@ pub(crate) async fn handle_request(
             }
             (reply, result)
         }
+        GuiRequest::ReadClipboard { reply } => {
+            let _ = reply.send(clipboard_text(editor));
+            return;
+        }
+        GuiRequest::WriteClipboard { text, reply } => {
+            let result = match clipboard::within_limit(&text) {
+                // Straight into the `+` register, which is where `p` reads
+                // from under `clipboard=unnamedplus` and where `"+p` reads
+                // from whatever the option says.
+                Ok(()) => {
+                    editor.registers_mut().set_clipboard(text);
+                    Ok(())
+                }
+                Err(error) => Err(anyhow::anyhow!(error)),
+            };
+            (reply, result)
+        }
         GuiRequest::Shutdown => unreachable!(),
     };
 
@@ -1112,6 +1131,13 @@ pub fn snapshot(editor: &Editor, revision: u64, inputs: u64) -> GuiSnapshot {
         theme: theme(editor),
         predictable_insert: echo::predictable_insert(editor),
         input_epoch: inputs,
+        clipboard: GuiClipboard {
+            // Read as a boolean rather than by value: nothing in the editor
+            // distinguishes `unnamedplus` from `unnamed`, so a frontend must
+            // not pretend to either.
+            shared: !editor.options.clipboard.is_empty(),
+            generation: editor.registers().clipboard_generation(),
+        },
         should_quit: editor.should_quit(),
     }
 }

--- a/ovim/src/gui/protocol.rs
+++ b/ovim/src/gui/protocol.rs
@@ -758,6 +758,32 @@ impl GuiCommand {
             | GuiCommand::SelectDebugFrame { .. } => GuiReplyKind::Unit,
         }
     }
+
+    /// Whether this command has to reach the editor in the order it was issued.
+    ///
+    /// In a modal editor almost every command means whatever the mode, pending
+    /// operator, count and cursor make it mean *when it arrives*: `d` before
+    /// its motion and `d` after it delete different things, and two characters
+    /// that swap places corrupt the buffer with nothing on screen to say so.
+    /// So the answer is yes by default, and a new variant added later inherits
+    /// the safe side of it.
+    ///
+    /// The exceptions are the read-only queries. None of them touches editor
+    /// state, so where they sit in the sequence cannot change what any other
+    /// command does; and their own answer already describes the editor at
+    /// whatever moment the session got round to them, which no client could
+    /// pin down anyway. They are also the slow ones -- the diff commands walk
+    /// Git objects on the session's blocking pool -- so keeping them out of
+    /// the ordered queue is what stops a repository walk from sitting in front
+    /// of the keys typed during it.
+    pub fn must_keep_its_place(&self) -> bool {
+        !matches!(
+            self,
+            GuiCommand::VectorSource
+                | GuiCommand::DiffReview { .. }
+                | GuiCommand::DiffFilePatch { .. }
+        )
+    }
 }
 
 /// Which [`GuiReply`] a [`GuiCommand`] answers with.
@@ -1004,6 +1030,21 @@ mod tests {
         .unwrap();
 
         assert_eq!(json["payload"]["displayColumn"], 8);
+    }
+
+    #[test]
+    fn a_command_that_leaves_the_ordered_queue_is_one_that_only_reads() {
+        // Ordering is the default so that a variant added later cannot opt out
+        // of it by being forgotten. The exceptions are exactly the queries,
+        // and each of those answers with a computed value rather than the
+        // `Unit` an editor-state change comes back as.
+        for command in sample_commands() {
+            let reads_only = matches!(
+                command.reply_kind(),
+                GuiReplyKind::VectorSource | GuiReplyKind::DiffReview | GuiReplyKind::DiffPatch
+            );
+            assert_eq!(command.must_keep_its_place(), !reads_only, "{command:?}");
+        }
     }
 
     #[test]

--- a/ovim/src/gui/protocol.rs
+++ b/ovim/src/gui/protocol.rs
@@ -150,7 +150,48 @@ pub struct GuiSnapshot {
     /// what the editor has consumed of one client's typing, and overstating
     /// makes that client speak for less rather than more.
     pub input_epoch: u64,
+    /// What the editor's system-clipboard policy is doing.
+    ///
+    /// A frontend driving an editor on another host has to mirror the policy
+    /// rather than invent one, and the two facts it needs are cheap enough to
+    /// ride on every frame. The clipboard *text* deliberately does not: a
+    /// yanked buffer can be megabytes, and a snapshot is a full projection
+    /// with no delta encoding, so a large yank would be re-sent with every
+    /// keystroke's frame. [`GuiCommand::ReadClipboard`] fetches it once, when
+    /// the generation says there is something new to fetch.
+    pub clipboard: GuiClipboard,
     pub should_quit: bool,
+}
+
+/// The editor's system-clipboard policy, as seen from a frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuiClipboard {
+    /// Whether `set clipboard=` asks for system-clipboard integration.
+    ///
+    /// False for `set clipboard=`, true for `unnamedplus` and `unnamed`. A
+    /// user who has not opted into clipboard integration must not acquire it
+    /// by moving the editor to another host, so this gates the direction that
+    /// sends the frontend's clipboard to the editor.
+    pub shared: bool,
+    /// How many times the editor has written the system clipboard.
+    ///
+    /// Rises only for a write the editor made -- so a yank, or a delete under
+    /// `unnamedplus`, or an explicit `"+y` whatever the option says. It does
+    /// not rise for a clipboard some other program on the editor's host
+    /// changed, which is the difference between mirroring the editor and
+    /// synchronising two machines' clipboards.
+    pub generation: u64,
+}
+
+/// The text the editor last put on its host's system clipboard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuiClipboardText {
+    /// The generation this text belongs to, which a frontend records so a
+    /// yank that lands between the frame and this answer is still noticed.
+    pub generation: u64,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -713,6 +754,20 @@ pub enum GuiCommand {
     SelectDebugFrame {
         index: usize,
     },
+    /// The text the editor last put on its own host's system clipboard.
+    ///
+    /// Asked for when [`GuiClipboard::generation`] on a frame differs from the
+    /// one already mirrored, so the payload crosses the link once per yank
+    /// rather than once per frame.
+    ReadClipboard,
+    /// Put the frontend's system clipboard into the editor's `+` register.
+    ///
+    /// The other half of the bridge: without it a `p` on a remote editor pastes
+    /// whatever the *editor's* host has on its clipboard, which on a headless
+    /// host is usually nothing at all.
+    WriteClipboard {
+        text: String,
+    },
     Shutdown,
 }
 
@@ -728,6 +783,7 @@ impl GuiCommand {
             GuiCommand::VectorSource => GuiReplyKind::VectorSource,
             GuiCommand::DiffReview { .. } => GuiReplyKind::DiffReview,
             GuiCommand::DiffFilePatch { .. } => GuiReplyKind::DiffPatch,
+            GuiCommand::ReadClipboard => GuiReplyKind::Clipboard,
             GuiCommand::Shutdown => GuiReplyKind::None,
             GuiCommand::VectorFeedback { .. }
             | GuiCommand::OpenDiffBuffer { .. }
@@ -755,7 +811,8 @@ impl GuiCommand {
             | GuiCommand::SelectFileTree { .. }
             | GuiCommand::SelectProblem { .. }
             | GuiCommand::SelectLsp { .. }
-            | GuiCommand::SelectDebugFrame { .. } => GuiReplyKind::Unit,
+            | GuiCommand::SelectDebugFrame { .. }
+            | GuiCommand::WriteClipboard { .. } => GuiReplyKind::Unit,
         }
     }
 
@@ -782,6 +839,7 @@ impl GuiCommand {
             GuiCommand::VectorSource
                 | GuiCommand::DiffReview { .. }
                 | GuiCommand::DiffFilePatch { .. }
+                | GuiCommand::ReadClipboard
         )
     }
 }
@@ -799,6 +857,7 @@ pub enum GuiReplyKind {
     VectorSource,
     DiffReview,
     DiffPatch,
+    Clipboard,
 }
 
 /// The answer to a [`GuiCommand`].
@@ -820,6 +879,8 @@ pub enum GuiReply {
     DiffReview(Result<ovim_core::native_diff::DiffReview, String>),
     /// A unified patch for one file, computed on the editor's host.
     DiffPatch(Result<String, String>),
+    /// The text the editor last put on its own host's system clipboard.
+    Clipboard(Result<GuiClipboardText, String>),
 }
 
 impl GuiReply {
@@ -831,6 +892,7 @@ impl GuiReply {
             GuiReply::VectorSource(_) => GuiReplyKind::VectorSource,
             GuiReply::DiffReview(_) => GuiReplyKind::DiffReview,
             GuiReply::DiffPatch(_) => GuiReplyKind::DiffPatch,
+            GuiReply::Clipboard(_) => GuiReplyKind::Clipboard,
         }
     }
 }
@@ -977,6 +1039,10 @@ pub(super) fn sample_commands() -> Vec<GuiCommand> {
             activate: false,
         },
         GuiCommand::SelectDebugFrame { index: 2 },
+        GuiCommand::ReadClipboard,
+        GuiCommand::WriteClipboard {
+            text: "clipboard text".to_string(),
+        },
         GuiCommand::Shutdown,
         GuiCommand::Key { input: plain_key },
     ]
@@ -990,13 +1056,13 @@ mod tests {
 
     #[test]
     fn the_command_sample_covers_every_variant_exactly_once() {
-        // `GuiRequest` has 32 variants and `GuiCommand` mirrors it one for
+        // `GuiRequest` has 34 variants and `GuiCommand` mirrors it one for
         // one, so this count is what stops a new variant from being added
         // without round-trip coverage. The trailing duplicate in the sample is
         // a second `Key` with different modifiers, which is deliberate.
         let commands = sample_commands();
         let distinct: HashSet<_> = commands.iter().map(discriminant).collect();
-        assert_eq!(distinct.len(), 32);
+        assert_eq!(distinct.len(), 34);
     }
 
     #[test]
@@ -1041,7 +1107,10 @@ mod tests {
         for command in sample_commands() {
             let reads_only = matches!(
                 command.reply_kind(),
-                GuiReplyKind::VectorSource | GuiReplyKind::DiffReview | GuiReplyKind::DiffPatch
+                GuiReplyKind::VectorSource
+                    | GuiReplyKind::DiffReview
+                    | GuiReplyKind::DiffPatch
+                    | GuiReplyKind::Clipboard
             );
             assert_eq!(command.must_keep_its_place(), !reads_only, "{command:?}");
         }
@@ -1062,6 +1131,11 @@ mod tests {
             GuiReply::DiffPatch(Ok("@@ -1 +1 @@\n-old\n+new\n".to_string())),
             GuiReply::DiffPatch(Err("no workspace".to_string())),
             GuiReply::Snapshot(Box::new(Err("the editor stopped".to_string()))),
+            GuiReply::Clipboard(Ok(GuiClipboardText {
+                generation: 7,
+                text: "yanked".to_string(),
+            })),
+            GuiReply::Clipboard(Err("the yank is too large to bridge".to_string())),
         ] {
             assert_eq!(round_trip(&reply), reply);
         }
@@ -1078,6 +1152,7 @@ mod tests {
                 GuiReplyKind::VectorSource => GuiReply::VectorSource(Err("unused".to_string())),
                 GuiReplyKind::DiffReview => GuiReply::DiffReview(Err("unused".to_string())),
                 GuiReplyKind::DiffPatch => GuiReply::DiffPatch(Err("unused".to_string())),
+                GuiReplyKind::Clipboard => GuiReply::Clipboard(Err("unused".to_string())),
             };
             assert_eq!(reply.kind(), kind, "{command:?}");
         }

--- a/ovim/src/gui/remote.rs
+++ b/ovim/src/gui/remote.rs
@@ -952,6 +952,11 @@ mod tests {
                 "@@ -1 +1 @@\n-old\n+new\n".to_string()
             )))
             .into_response(),
+            GuiReplyKind::Clipboard => Json(GuiReply::Clipboard(Ok(protocol::GuiClipboardText {
+                generation: 1,
+                text: "yanked".to_string(),
+            })))
+            .into_response(),
         }
     }
 

--- a/ovim/src/gui/remote.rs
+++ b/ovim/src/gui/remote.rs
@@ -20,6 +20,11 @@
 //!   failed inside the editor still answers `200` with an `Err` reply, so this
 //!   transport passes replies through untouched and only invents an error when
 //!   the link itself failed.
+//! * **Order is part of what a command means.** Two POSTs issued back to back
+//!   are two independent requests, and nothing in HTTP makes the second reach
+//!   the session after the first. In a modal editor that is a corruption bug
+//!   rather than a rendering one, so ordered commands leave through a single
+//!   writer task -- see [`write_in_order`].
 
 use super::bridge::{GuiTransport, GuiTransportFuture, EDITOR_STOPPED};
 use super::protocol::{GuiCommand, GuiReply, GuiReplyKind, GuiSnapshot, SNAPSHOT_EVENT};
@@ -33,7 +38,7 @@ use reqwest::StatusCode;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{oneshot, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 
 /// The link to the editor failed, so the command never reached it.
 ///
@@ -230,9 +235,58 @@ impl Wire {
     }
 }
 
+/// One queued command and the channel its answer is owed on.
+struct Envelope {
+    command: GuiCommand,
+    answer: oneshot::Sender<Result<Option<GuiReply>, String>>,
+}
+
+/// Put ordered commands on the wire one at a time, in the order they were
+/// queued.
+///
+/// Two concurrent POSTs are two independent requests: they may travel on
+/// different connections, and the session hands each to its own task before
+/// anything reaches the editor's single request queue. Nothing about that
+/// preserves the order they were issued in, and in a modal editor the order is
+/// the meaning -- a `d` that overtakes its motion deletes something else, a
+/// count that arrives after the operator it belonged to is simply lost, and two
+/// typed characters that swap places corrupt the buffer with nothing on screen
+/// to say so. R7's epoch fence turns such a reorder into a dropped prediction
+/// rather than wrong text drawn locally, but the wrong text is already in the
+/// buffer by then.
+///
+/// A single writer awaiting each answer before starting the next request is
+/// what makes the session receive them in issue order, since the answer cannot
+/// arrive before the editor has taken the command in. The cost is that the
+/// ordered lane carries one command per round trip; see the module notes in
+/// `planning/remote-editing/PLAN.md` for why that is the right trade here and
+/// what would lift it.
+///
+/// The connection is re-checked here rather than only at
+/// [`GuiTransport::send`]: a command sits in this queue for as long as the one
+/// in front of it takes, and a link that dies in between must drop what is
+/// waiting instead of releasing it into a session that has been edited
+/// meanwhile. Releasing a backlog on reconnect is the replay R6 refused, just
+/// arriving by a different door.
+async fn write_in_order(link: Arc<Link>, mut queue: mpsc::UnboundedReceiver<Envelope>) {
+    while let Some(Envelope { command, answer }) = queue.recv().await {
+        let result = if link.is_connected() {
+            post_command(&link.wire(), command).await
+        } else {
+            Err(EDITOR_DISCONNECTED.to_string())
+        };
+        // The caller may have gone away; the command still had to be sent in
+        // its place, so a closed answer channel is not a reason to skip it.
+        let _ = answer.send(result);
+    }
+}
+
 /// The transport: a supervised link to a session, and the runtime it runs on.
 pub struct RemoteTransport {
     link: Arc<Link>,
+    /// The ordered lane. See [`write_in_order`].
+    ordered: mpsc::UnboundedSender<Envelope>,
+    writer: tokio::task::JoinHandle<()>,
     supervisor: tokio::task::JoinHandle<()>,
     /// Owned so that requests never depend on the caller's runtime.
     ///
@@ -290,9 +344,13 @@ impl RemoteTransport {
         let link = Arc::new(Link::new(Wire::new(&launch.endpoint)?, launch.link));
         let (ready_tx, ready_rx) = oneshot::channel();
         let supervisor = runtime.spawn(supervise(Arc::clone(&link), ready_tx));
+        let (ordered, queue) = mpsc::unbounded_channel();
+        let writer = runtime.spawn(write_in_order(Arc::clone(&link), queue));
         Ok((
             Self {
                 link,
+                ordered,
+                writer,
                 supervisor,
                 runtime: Some(runtime),
             },
@@ -315,13 +373,38 @@ impl RemoteTransport {
         self.link.request_reconnect(allow_new_session)
     }
 
-    /// Start the request immediately and hand back where its answer will land.
+    /// Queue the request immediately and hand back where its answer will land.
     ///
-    /// Eager like the local transport's send: the caller's first `await` is
-    /// not what puts the command on the wire.
+    /// Eager like the local transport's send: the caller's first `await` is not
+    /// what decides this command's place in the sequence. Taking that place
+    /// here, synchronously, is what makes "issued before" mean "arrives
+    /// before" -- two `send` calls from one task are ordered by the calls
+    /// themselves rather than by which future is polled first.
+    ///
+    /// Two lanes, split by [`GuiCommand::must_keep_its_place`]. Everything that
+    /// touches editor state goes through [`write_in_order`]; the read-only
+    /// queries get a task each, as every command used to. That is not a
+    /// loophole but the point of the split: the diff commands walk a Git
+    /// repository on the session's blocking pool and can take seconds, and a
+    /// keystroke typed while a diff panel refreshes must not wait behind it.
+    /// A query cannot change what any other command does, so letting it
+    /// overtake one costs nothing -- and its answer was never pinned to a
+    /// moment in the sequence anyway, since it describes the editor as of
+    /// whenever the session got round to it.
     fn dispatch(&self, command: GuiCommand) -> oneshot::Receiver<Result<Option<GuiReply>, String>> {
         let (answer_tx, answer_rx) = oneshot::channel();
         self.link.note_viewport(&command);
+        if command.must_keep_its_place() {
+            // A failed send drops the answer channel with the envelope, which
+            // the caller reads as the editor being unreachable -- the same
+            // wording a spawned request gets when the runtime goes away under
+            // it, and only reachable for the same reason.
+            let _ = self.ordered.send(Envelope {
+                command,
+                answer: answer_tx,
+            });
+            return answer_rx;
+        }
         let link = Arc::clone(&self.link);
         self.runtime().spawn(async move {
             let _ = answer_tx.send(post_command(&link.wire(), command).await);
@@ -418,6 +501,7 @@ impl GuiTransport for RemoteTransport {
 impl Drop for RemoteTransport {
     fn drop(&mut self) {
         self.supervisor.abort();
+        self.writer.abort();
         // Dropping a runtime from inside another one panics, and a GUI shell
         // may well be tearing this down from an async context. Handing the
         // runtime its own shutdown avoids waiting for tasks here.
@@ -671,6 +755,14 @@ mod tests {
     const FAILING_COMMAND: &str = "make the editor refuse";
     /// A command the stub answers as a broken conversation instead.
     const UNAVAILABLE_COMMAND: &str = "make the conversation fail";
+    /// A command the stub sits on before recording it, followed by a number of
+    /// milliseconds.
+    ///
+    /// This is how a test forces an arrival order the client never asked for:
+    /// commands issued in one order but held for descending times are recorded
+    /// in exactly the reverse of it, unless something made them travel one at
+    /// a time.
+    const HOLD_COMMAND: &str = "hold for ";
 
     /// A session that answers like the real one without running an editor.
     struct StubSession {
@@ -690,6 +782,9 @@ mod tests {
         /// The revision the next published frame carries, so a test can make
         /// the session look like a replacement that started counting again.
         revision: Mutex<u64>,
+        /// How long a diff query takes, standing in for the Git walk the real
+        /// session runs on its blocking pool.
+        diff_delay: Mutex<Duration>,
     }
 
     impl StubSession {
@@ -724,6 +819,26 @@ mod tests {
         /// Answer the stream route with `status` until told otherwise.
         fn refuse_stream(&self, status: Option<AxumStatus>) {
             *self.refuse_stream.lock().unwrap() = status;
+        }
+
+        /// Make every diff query take `delay`, as a repository walk would.
+        fn hold_diffs_for(&self, delay: Duration) {
+            *self.diff_delay.lock().unwrap() = delay;
+        }
+
+        /// How long to sit on `command` before recording it as arrived.
+        fn hold_for(&self, command: &GuiCommand) -> Duration {
+            match command {
+                GuiCommand::EditorCommand { command } => command
+                    .strip_prefix(HOLD_COMMAND)
+                    .and_then(|milliseconds| milliseconds.parse().ok())
+                    .map(Duration::from_millis)
+                    .unwrap_or_default(),
+                GuiCommand::DiffReview { .. } | GuiCommand::DiffFilePatch { .. } => {
+                    *self.diff_delay.lock().unwrap()
+                }
+                _ => Duration::ZERO,
+            }
         }
     }
 
@@ -799,6 +914,12 @@ mod tests {
             GuiCommand::EditorCommand { command } => command.clone(),
             _ => String::new(),
         };
+        // Recorded after the hold, not before it: the list is what the session
+        // took in, and a command still travelling has not arrived.
+        let hold = stub.hold_for(&command);
+        if !hold.is_zero() {
+            tokio::time::sleep(hold).await;
+        }
         stub.received.lock().unwrap().push(command);
         if scripted == UNAVAILABLE_COMMAND {
             return (
@@ -901,6 +1022,7 @@ mod tests {
             streams: Mutex::new(0),
             refuse_stream: Mutex::new(None),
             revision: Mutex::new(0),
+            diff_delay: Mutex::new(Duration::ZERO),
         });
         let routes = Router::new()
             .route("/gui/command", post(stub_command))
@@ -1076,6 +1198,118 @@ mod tests {
         let arrived = Arc::clone(&stub);
         eventually(|| arrived.received().len() == expected.len()).await;
         assert_eq!(stub.received(), expected);
+    }
+
+    /// Only the ex commands, in the order the stub recorded them.
+    fn editor_commands(stub: &StubSession) -> Vec<String> {
+        stub.received()
+            .into_iter()
+            .filter_map(|command| match command {
+                GuiCommand::EditorCommand { command } => Some(command),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn commands_reach_the_session_in_the_order_they_were_issued() {
+        // The bug this pins down is a correctness one, not a rendering one: an
+        // operator that overtakes its motion deletes something else, and a
+        // count that lands after the operator it belonged to is simply gone.
+        //
+        // The stub holds each command for a time that falls as the sequence
+        // advances, so a client that put them all on the wire at once would
+        // have them recorded in exactly the reverse of the order it issued
+        // them in. Nothing but sending them one at a time produces this list.
+        let (stub, endpoint) = stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let issued: Vec<String> = (0..6)
+            .map(|index| format!("{HOLD_COMMAND}{}", 250 - index * 40))
+            .collect();
+
+        let sends: Vec<_> = issued
+            .iter()
+            .map(|command| {
+                transport.send(GuiCommand::EditorCommand {
+                    command: command.clone(),
+                })
+            })
+            .collect();
+        for outcome in futures::future::join_all(sends).await {
+            outcome.expect("every command should be answered");
+        }
+
+        assert_eq!(editor_commands(&stub), issued);
+    }
+
+    #[tokio::test]
+    async fn a_repository_walk_does_not_hold_up_the_keys_typed_during_it() {
+        // The reason the ordered queue is not simply every command. A diff
+        // review walks Git objects on the session's blocking pool and can take
+        // seconds; the keys typed while a diff panel refreshes must not wait
+        // behind it. A query changes no editor state, so letting it be
+        // overtaken cannot change what anything else does.
+        let (stub, endpoint) = stub_session().await;
+        stub.hold_diffs_for(Duration::from_millis(600));
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+
+        let review = transport.send(GuiCommand::DiffReview { spec: None });
+        let typed = async {
+            let started = std::time::Instant::now();
+            let outcome = transport
+                .send(GuiCommand::EditorCommand {
+                    command: "set number".to_string(),
+                })
+                .await;
+            (outcome, started.elapsed())
+        };
+        let (review, (typed, waited)) = futures::future::join(review, typed).await;
+
+        review.expect("the review answers once its walk is done");
+        typed.expect("the key is answered on its own");
+        assert!(
+            waited < Duration::from_millis(300),
+            "the key waited {waited:?}"
+        );
+        // And it reached the session first, which is the same fact stated
+        // where a slow machine cannot argue with it.
+        assert_eq!(editor_commands(&stub), vec!["set number".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn a_command_waiting_its_turn_is_dropped_when_the_link_dies_under_it() {
+        // Queueing is how ordering is bought, and a queue is exactly what R6
+        // refused to let a reconnect release: the session kept being edited
+        // while the client was blind, so a key delivered late acts on a buffer
+        // nobody watched move. The refusal at `send` covers a key typed during
+        // the outage; this covers one that was already waiting when it began.
+        let (stub, forwarder, endpoint) = forwarded_stub_session().await;
+        let transport = RemoteTransport::open(endpoint).await.unwrap();
+        let mut connection = transport.connection();
+
+        let ahead = transport.send(GuiCommand::EditorCommand {
+            command: format!("{HOLD_COMMAND}2000"),
+        });
+        let waiting = transport.send(GuiCommand::EditorCommand {
+            command: "d".to_string(),
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        forwarder.cut();
+        connection_reaches(&mut connection, |state| !state.is_connected()).await;
+        assert!(ahead.await.is_err(), "the cut should have failed it");
+        assert!(
+            waiting.await.is_err(),
+            "the queued command should be refused"
+        );
+        forwarder.mend();
+        connection_reaches(&mut connection, GuiConnection::is_connected).await;
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !editor_commands(&stub).iter().any(|command| command == "d"),
+            "a queued command must not be delivered after the link returns: {:?}",
+            editor_commands(&stub)
+        );
     }
 
     #[tokio::test]

--- a/ovim/tests/remote_session_test.rs
+++ b/ovim/tests/remote_session_test.rs
@@ -10,6 +10,11 @@
 //!     cargo test --test remote_session_test -- --ignored --nocapture
 //! ```
 //!
+//! They all drive the one session the variable names, and some of them type
+//! into it, so run them one at a time against a session started for the
+//! purpose -- two of them editing one buffer at once is not a failure of
+//! either.
+//!
 //! `OVIM_REMOTE_ENDPOINT` optionally says where to dial -- `HOST:PORT`, or a
 //! bare port on loopback. That is how the same test covers a forwarded port:
 //! the descriptor still fixes the Host header the session insists on, while
@@ -367,4 +372,135 @@ async fn a_forward_that_dies_and_comes_back_leaves_the_session_untouched() {
             .await
             .expect("the reattached session should take keys again");
     }
+}
+
+/// A clipboard in memory, standing in for the laptop's.
+///
+/// Deliberately not the real one. The session in this test runs on the same
+/// machine as the test, so a real clipboard on both ends would be one
+/// clipboard, and the bridge would appear to work while doing nothing.
+#[derive(Default)]
+struct TestClipboard {
+    held: std::sync::Mutex<Option<String>>,
+}
+
+impl TestClipboard {
+    fn contents(&self) -> Option<String> {
+        self.held.lock().unwrap().clone()
+    }
+
+    fn put(&self, text: &str) {
+        *self.held.lock().unwrap() = Some(text.to_string());
+    }
+}
+
+impl ovim::gui::clipboard::LocalClipboard for TestClipboard {
+    fn read(&self) -> Option<String> {
+        self.held.lock().unwrap().clone()
+    }
+
+    fn write(&self, text: &str) {
+        *self.held.lock().unwrap() = Some(text.to_string());
+    }
+}
+
+/// Wait until this machine's clipboard holds something matching `wanted`.
+async fn clipboard_reaches(local: &TestClipboard, wanted: impl Fn(&str) -> bool) -> String {
+    for _ in 0..200 {
+        if let Some(held) = local.contents() {
+            if wanted(&held) {
+                return held;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!(
+        "the clipboard never reached the expected contents (last: {:?})",
+        local.contents()
+    );
+}
+
+#[tokio::test]
+#[ignore = "needs a running headless session and socat; see the module comment"]
+async fn a_yank_crosses_the_link_to_this_clipboard_and_this_clipboard_crosses_back() {
+    // The papercut this chunk exists for, end to end and through a real
+    // forward: yank on the session and the text is on this machine's
+    // clipboard; copy on this machine and `p` on the session pastes it.
+    let descriptor = PathBuf::from(
+        std::env::var("OVIM_REMOTE_SESSION")
+            .expect("OVIM_REMOTE_SESSION must name a session descriptor"),
+    );
+    let session: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&descriptor).expect("a readable descriptor"))
+            .expect("a descriptor is JSON");
+    let session_port = session["port"].as_u64().expect("a port") as u16;
+    let forwarder = Socat::in_front_of(session_port);
+
+    let endpoint =
+        RemoteEndpoint::from_session_file(&descriptor, Some(&forwarder.port.to_string()))
+            .expect("the descriptor should describe a reachable session");
+    let bridge =
+        GuiBridge::new(Arc::new(RemoteTransport::open(endpoint).await.expect(
+            "the session should accept the transport through the forwarder",
+        )));
+    let local = Arc::new(TestClipboard::default());
+    let (clipboard, follow) = ovim::gui::clipboard::start(&bridge, local.clone())
+        .expect("a session on the far side of a transport needs the bridge");
+    tokio::spawn(follow);
+    let mut updates = bridge.subscribe();
+    let first = next_frame(&mut updates).await;
+    println!(
+        "connected through port {}: first line {:?}, clipboard {:?}",
+        forwarder.port,
+        line_text(&first, 0),
+        first.clipboard
+    );
+    assert!(
+        first.clipboard.shared,
+        "this test assumes the session's default clipboard=unnamedplus"
+    );
+
+    // Session to laptop: yank the first line and watch it arrive here.
+    for key in ["Escape", "g", "g", "y", "y"] {
+        bridge
+            .key(typed(key))
+            .await
+            .unwrap_or_else(|error| panic!("{key} should reach the session: {error}"));
+    }
+    let arrived = clipboard_reaches(&local, |held| held.contains("yank me")).await;
+    println!("the session's yank reached this machine: {arrived:?}");
+
+    // Laptop to session: copy here, hand it over on activation, and paste.
+    local.put("pasted from the laptop");
+    clipboard.push_latest().await;
+    for key in ["G", "p"] {
+        bridge
+            .key(typed(key))
+            .await
+            .unwrap_or_else(|error| panic!("{key} should reach the session: {error}"));
+    }
+    let mut pasted = next_frame(&mut updates).await;
+    for _ in 0..40 {
+        if (0..pasted.lines.len())
+            .any(|index| line_text(&pasted, index).contains("pasted from the laptop"))
+        {
+            println!("this machine's clipboard was pasted into the session");
+            // Put the buffer and the cursor back: these tests may share one
+            // session, and one that edits has to leave what it found.
+            for key in ["u", "g", "g"] {
+                bridge
+                    .key(typed(key))
+                    .await
+                    .expect("the session should take the tidying up");
+            }
+            return;
+        }
+        pasted = next_frame(&mut updates).await;
+    }
+    panic!(
+        "the session never pasted this machine's clipboard: {:?}",
+        (0..pasted.lines.len())
+            .map(|index| line_text(&pasted, index))
+            .collect::<Vec<_>>()
+    );
 }

--- a/planning/remote-editing/PLAN.md
+++ b/planning/remote-editing/PLAN.md
@@ -130,7 +130,8 @@ confirmation state, limited to safely predictable keys.
 
 ### R8 — Clipboard bridging
 A yank on the remote fills a remote register. Bridge it to the local system
-clipboard, and the reverse for paste. Daily papercut if skipped.
+clipboard, and the reverse for paste. Daily papercut if skipped. Mirrors the
+`clipboard` option rather than adding a policy.
 
 ### R9 — Documentation
 `user-docs/remote.md`, plus README and CLAUDE.md updates.
@@ -425,6 +426,67 @@ the local one.
 - Not measured: the effect of the completion-menu exclusion on the hit rate.
   `rust-analyzer` would not attach to a headless session on this machine, so
   every measurement above is LSP-free and the menu never opened.
+
+**R8 landed; notes for R9.**
+
+- **The clipboard policy is Ovim's own, observed rather than reinvented.** The
+  `clipboard` option (`unnamedplus` by default, `unnamed`, or empty) already
+  decides *whether* a yank belongs on the system clipboard; the only new
+  question is *whose*. `ovim/src/gui/clipboard.rs` answers that and adds no
+  case of its own.
+- **Editor to laptop** rides on a counter, not on the text. `ClipboardProvider`
+  bumps a generation on every write, `GuiSnapshot.clipboard.generation` carries
+  it, and the client fetches with `GuiCommand::ReadClipboard` only when it
+  moves. The text deliberately never rides on a frame: a snapshot is a full
+  projection with no delta encoding, so a megabyte yank would be re-sent with
+  every subsequent keystroke's frame. The counter rises exactly when a local
+  Ovim would have written the user's clipboard -- a yank or delete under
+  `unnamedplus`, an explicit `"+y` whatever the option says -- so mirroring
+  every rise reproduces the local exposure rather than inventing a new one.
+  It is compared for *inequality*, because a replaced session starts counting
+  from one again; the same trap `Link::publish` guards the revision against.
+- **Laptop to editor** is gated on the option read as a boolean
+  (`clipboard.shared`), because this is the direction that moves the user's
+  clipboard onto another host. `unnamedplus` is the declaration that makes it
+  defensible; somebody on `set clipboard=` gets nothing, and their Cmd-V still
+  works because `gui_paste` is an explicit per-paste gesture and always was.
+  The trigger is window activation -- the one moment between "copied in a
+  browser" and "pressed `p`" this process can see. `p` cannot ask at the time:
+  the snapshot stream is the only channel running the other way and it carries
+  frames, not questions. **A pending-paste request on the frame would be the
+  honest fix and is a follow-up**, but it makes every `p` cost a round trip.
+- **Both directions run in this process, not in the webview.** The client
+  already links `ovim-core`, so it has the same `arboard` the editor does:
+  identical semantics to a local Ovim, no clipboard-permission prompt, no
+  dependence on a DOM gesture, and no clipboard content through the IPC. The
+  image path had to go through the webview because only a `ClipboardEvent`
+  carries image bytes; text has no such constraint.
+- **1 MiB either way**, enforced where the text is (the editor refuses to hand
+  over more; the client refuses to send more). Roughly fifteen thousand lines
+  of source, past anything anyone pastes by hand, and about a second of a
+  laptop's uplink where the image path's 20 MiB would be twenty. The asymmetry
+  is deliberate: a pasted screenshot has no smaller form, whereas an oversized
+  yank is still in the remote register with better ways to travel.
+- Nothing is queued while disconnected: `RemoteTransport::send` refuses, the
+  push forgets what it tried to send, and the next activation sends whatever is
+  on the clipboard *then* -- which is the value the user would expect anyway.
+- A push raises the editor's generation, so the mirror that follows would write
+  the text straight back. It is skipped by comparing against what this
+  machine's clipboard already holds, which costs one read per yank and stops
+  the two directions chasing each other.
+- Verified live: a headless session started with no display (so `arboard` is
+  unavailable there, exactly as on a real remote), driven through a `socat`
+  forward, with an in-memory stand-in for the laptop's clipboard so that one
+  machine cannot fake the round trip. `yy` on the session reached the
+  stand-in; text put on the stand-in was pasted by `p` on the session;
+  `set clipboard=` flipped `shared` to false on the very next frame.
+  `remote_session_test::a_yank_crosses_the_link_to_this_clipboard_and_this_clipboard_crosses_back`
+  is that drill, ignored by default.
+- Not verified: the `WindowEvent::Focused(true)` hook itself, which needs a
+  real window. The handler is two lines over `push_latest`, which the test
+  drives directly.
+- R9 should document `clipboard` under remote editing: what crosses, in which
+  direction, and that `set clipboard=` turns the laptop-to-editor half off.
 
 ## Known follow-ups after R7
 

--- a/planning/remote-editing/PLAN.md
+++ b/planning/remote-editing/PLAN.md
@@ -536,3 +536,20 @@ the obvious next candidate, but it needs its own correctness argument.
 visible (only Tab/Enter/Ctrl-Y accept). The exclusion was kept because it could
 not be verified live -- no language server would attach to a headless session
 in the development environment.
+
+## Test hazard: `test_clipboard_register_yank`
+
+`ovim/tests/register_operations_test.rs::test_clipboard_register_yank` drives
+`"+yiw` / `"+p` through the *real* system clipboard. On Wayland, clipboard
+ownership requires the writing process to stay alive and serve the selection,
+so a short-lived test process can lose it before reading back -- the paste then
+produces nothing and the assertion fails with the unpasted buffer.
+
+Measured at roughly 3 failures in 19 runs locally. Investigated during R8 and
+**not** attributable to it: the `register.rs` changes there are purely additive
+(two free functions, a generation counter) and the read path is untouched. It
+is environmental, not a regression, and it predates the remote-editing work.
+
+Worth making independent of the machine's clipboard, since it will be flaky in
+CI for the same reason. Left alone here rather than edited inside an unrelated
+change.

--- a/planning/remote-editing/PLAN.md
+++ b/planning/remote-editing/PLAN.md
@@ -428,15 +428,42 @@ the local one.
 
 ## Known follow-ups after R7
 
-**Concurrent key sends can reorder.** `RemoteTransport::dispatch` spawns a task
-per command, so two POSTs can race and reach the session out of order. This is
-pre-existing from R4, not introduced by predictive echo. In a modal editor an
-out-of-order key is a correctness problem, not just a display one: `d` arriving
-after its motion means something different from `d` arriving before it. The
-epoch fence added in R7 degrades a reorder into a dropped prediction rather
-than wrong text on screen, but it does not stop the reorder itself. Fixing it
-means serialising sends per transport -- a single-writer task with an ordered
-queue -- rather than one task per command.
+**Concurrent key sends could reorder -- fixed.** `RemoteTransport::dispatch`
+spawned a task per command, so two POSTs could race and reach the session out
+of order. Pre-existing from R4, and a correctness problem rather than a display
+one: `d` arriving after its motion means something different from `d` arriving
+before it, and R7's epoch fence only degraded a reorder into a dropped
+prediction, leaving the wrong text already in the buffer. The fix:
+
+- `GuiCommand::must_keep_its_place` splits the command set in two, with
+  ordering as the default so a variant added later inherits the safe side.
+  Everything that touches editor state goes through `write_in_order`, a single
+  writer task that awaits each answer before starting the next request -- the
+  answer cannot arrive before the editor has taken the command in, so issue
+  order is arrival order.
+- The exceptions are the three read-only queries (`VectorSource`,
+  `DiffReview`, `DiffFilePatch`), which keep a task each. **Head-of-line
+  blocking is real and this is what handles it**: a diff review walks Git
+  objects on the session's blocking pool and can take seconds, and keys typed
+  while a diff panel refreshes must not wait behind it. Letting a query be
+  overtaken is safe because it changes no editor state -- so its position in
+  the sequence cannot change what any other command does -- and its answer
+  already describes the editor as of whenever the session got round to it,
+  which no client could pin down even before.
+- The writer re-checks the connection before each send, so a command that was
+  merely *waiting* when the link died is dropped rather than released into a
+  session that was edited meanwhile. Releasing a backlog on reconnect is the
+  replay R6 refused, arriving by a different door.
+- **The cost: the ordered lane carries one command per round trip**, so
+  sustained typing faster than 1/RTT builds a backlog that drains in the
+  pauses. At the 40ms where R7 says predictive echo becomes required that is
+  25 keys/s, which is the rate R7 measured real typing at; at 150ms it is
+  under 7. Predictive echo hides the visual part (`outstanding = sentEpoch -
+  frame.inputEpoch` simply grows), but an unmodelled key ends the run and the
+  catch-up becomes visible. Lifting it needs the session to accept a batch, or
+  a sequence number it can reorder on -- both are protocol changes, and both
+  would have to answer what a *dropped* command does to a sequence the far
+  side is waiting to complete. Not attempted here.
 
 **Backspace is not predicted.** Auto-indent and `backspace=` interact in ways
 R7 could not prove safe. It is the most common excluded key in real typing and


### PR DESCRIPTION
Two unrelated pieces, one per commit so they can be read apart.

Stacked on #17.

---

# 1. `fix(gui): send remote commands in the order they were issued`

**A correctness bug, not a rendering one.** `RemoteTransport::dispatch` spawned a task per command, so two POSTs could race. In a modal editor `d` arriving after its motion means something different from `d` arriving before it; a dropped count or a swapped operator/motion corrupts the buffer silently. Introduced in #14 and latent through three PRs. #17's epoch fence degrades a reorder into a dropped prediction rather than wrong text on screen, but does not stop the reorder.

`dispatch` now enqueues **synchronously** inside `send`, so "issued before" means "queued before" regardless of which future gets polled first, and a single writer task awaits each POST before starting the next.

**Head-of-line blocking is real, and handled by a lane split.** `GuiCommand::must_keep_its_place` returns true by default, so a variant added later inherits the safe side. The three read-only queries (`VectorSource`, `DiffReview`, `DiffFilePatch`) opt out. Safe because they touch no editor state, so their position cannot change what another command does. Necessary because `DiffReview` walks Git objects and can take seconds — keys typed while a diff panel refreshes must not queue behind it.

The writer re-checks `is_connected()` immediately before each send, so a command that was merely *waiting* when the link died is dropped rather than released into a session that was edited meanwhile — the replay #16 refused, arriving by a different door.

**The test that fails against the old code:** `commands_reach_the_session_in_the_order_they_were_issued`. Hold times *descend* as the sequence advances, so parallel dispatch records them in exactly reverse order — deterministic, not probabilistic. Verified by reverting `dispatch`:

```
left:  ["hold for 50", "hold for 90", ... "hold for 250"]
right: ["hold for 250", "hold for 210", ... "hold for 50"]
```

## The cost, stated plainly

The ordered lane is one command per round trip, so sustained typing faster than 1/RTT builds a backlog that drains in the pauses — roughly 25 keys/s at 40ms, under 7 at 150ms. Predictive echo hides the visual part, but an unmodelled key ends the run and the catch-up becomes visible.

This is a real ceiling on fast typing over a slow link, and it is the price of not corrupting buffers. Lifting it needs batching, or a sequence number the session can reorder on — a protocol change that has to answer what a *dropped* command does to a sequence the far side is waiting for. Not attempted here; recorded in the plan.

---

# 2. `feat(gui): bridge the clipboard between a remote editor and this machine`

A yank on the remote filled a register on the remote host while the user's clipboard sat on the laptop. Yanking remotely and pasting into a local browser silently did nothing.

**Policy is mirrored from what the editor already does, not invented.** `arboard` lives in `ovim-core`, i.e. in the *editor* process, so a remote `+` register is the *server's* clipboard. `EditorOptions::clipboard` already defaults to `unnamedplus`. Editor→laptop therefore fires exactly when `ClipboardProvider::write` fires — when a local Ovim would have written the user's clipboard. Laptop→editor is gated on the same option, so `set clipboard=` opts out of both. Cmd-V still works regardless, being an explicit per-paste gesture.

**Text never rides on a snapshot.** A generation counter does, and the text is fetched with `ReadClipboard` only when it moves — snapshots have no delta encoding, so a megabyte yank would otherwise be re-sent with every keystroke. Compared for inequality rather than `>`, since a replaced session restarts its counter at one. A push raises the editor's generation, so the mirror that follows sees what this machine already holds and skips; the two directions don't chase each other.

**1 MiB bound**, both directions — about 15,000 lines of source, past anything pasted by hand, and roughly a second of a laptop's uplink where the image path's 20 MiB would be twenty. The asymmetry is deliberate: a screenshot has no smaller form, while an oversized yank is still sitting in the remote register with better ways to travel.

Round-tripped against a real headless session started with `env -u DISPLAY -u WAYLAND_DISPLAY` — so `arboard` is genuinely unavailable there, as on a real remote host — driven through a forward, with an in-memory stand-in for the laptop clipboard so one machine can't fake both ends.

## Known gap

`"+p` with `set clipboard=` still reads the *editor host's* clipboard. Fixing it needs the editor to ask at paste time, and there is no server→client request channel yet. Recorded in the plan.

---

# Flagged, not fixed

`register_operations_test::test_clipboard_register_yank` is flaky — roughly 3 failures in 19 runs locally. I investigated it rather than accepting the "pre-existing" label: the failure is the paste producing **nothing** (`"hello world\n"` instead of `"hello worldhello\n"`), which is the arboard-on-Wayland hazard where a short-lived process loses clipboard ownership before reading back. The `register.rs` changes here are purely additive and the read path is untouched, so there is no mechanism by which this PR causes it, and `main` shows the same class of behaviour.

It is worth making independent of the machine's real clipboard, since it will be flaky in CI for the same reason — but editing a test I cannot prove is wrong, inside an unrelated change, is the worse move.

Also pre-existing: the ignored end-to-end tests interfere with each other and must be run one at a time. Documented in that module's comment.