### PR TITLE
docs(remote): document editing over SSH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ovim
 
-Oxidized Vim — a snappy, batteries-included terminal editor with Vim keybindings, LSP support, and seamless headless mode.
+Oxidized Vim — a snappy, batteries-included editor with Vim keybindings, LSP support, a native GUI, and seamless headless mode.
 
 ## Quick Reference
 
@@ -12,6 +12,10 @@ cargo build --release
 ./target/release/ovim file.txt
 ./target/release/ovim src/main.rs:42:10
 ./target/release/ovim file.rs --headless --session dev
+
+# Native GUI (Tauri + SolidJS)
+./target/release/ovim gui file.rs
+./target/release/ovim gui --remote user@host /path/to/project   # edit over SSH
 
 # File operations (stateless — no session needed)
 ovim edit src/main.rs --old "foo" --new "bar"
@@ -39,34 +43,52 @@ ovim session cleanup --dry-run
 ovim session cleanup --max-age 7
 ```
 
-**Sessions are opt-in.** TUI mode doesn't register a session. Headless mode requires `--session NAME`. TUI users can opt in with `:session start NAME`.
+**Sessions are opt-in.** TUI mode doesn't register a session. Headless mode requires `--session NAME`. A session must be explicit at process startup — `:session start NAME` is deliberately kept as a migration error so an ordinary TUI instance never exposes a latent mutation surface. `:session stop` and `:session list` do work.
 
 ## Architecture
 
 ```
-ovim-core/               # Shared library crate
+ovim-core/                 # Shared library crate — the editor itself
 ├── src/
-│   ├── syntax/          # Tree-sitter grammars & highlighting
-│   │   ├── languages.rs # Language enum & detection
-│   │   └── queries/     # Custom .scm highlight queries
-│   ├── buffer/          # Rope-based text buffer (ropey)
-│   ├── lsp/             # LSP client implementation
+│   ├── editor/            # Core logic, operators, motions, AI, LSP actions
+│   │   ├── input/         # Key event handling (normal/, insert_mode.rs, commands/)
+│   │   │   └── normal/operators.rs  # d, c, y operator dispatch
+│   │   ├── operators.rs   # The `Operator` enum (d, c, y, >, <, gu, ...)
+│   │   ├── motions/       # Cursor movement (word.rs, paragraph.rs, ...)
+│   │   ├── lsp_integration.rs # Editor-side LSP actions + intent dispatch
+│   │   └── mod.rs         # Main editor state
+│   ├── syntax/            # Tree-sitter grammars & highlighting
+│   │   ├── languages.rs   # Language enum & detection
+│   │   └── queries/       # Custom .scm highlight queries
+│   ├── buffer/            # Rope-based text buffer (ropey)
+│   ├── lsp/               # LSP client implementation
+│   ├── session.rs         # Session descriptors (PID, port, capability)
 │   └── ...
-└── languages.toml       # Language configurations (embedded at compile time)
+└── languages.toml         # Language configurations (embedded at compile time)
 
-ovim/                    # Binary crate
+ovim/                      # Binary crate — frontends, CLI, API
 ├── src/
-│   ├── api/             # REST API (Axum) - /health, /lsp/status, /snapshot, etc.
-│   ├── editor/          # Core logic, operators, motions, LSP actions
-│   │   ├── input.rs     # Key event handling
-│   │   ├── operators.rs # d, c, y operators
-│   │   ├── motions.rs   # Cursor movement
-│   │   └── mod.rs       # Main editor state + LSP integration
-│   ├── frontend/        # Frontend-agnostic runtime plumbing (shared by TUI/headless/future GUI)
-│   ├── ui/              # Terminal UI (ratatui + crossterm)
-│   ├── cli.rs           # CLI argument parsing
-│   ├── subcommands.rs   # CLI subcommand handlers
-│   └── main.rs          # Event loops (TUI & headless)
+│   ├── api/               # REST API (Axum) — /v1/health, /v1/snapshot, ...
+│   │   └── gui.rs         # /v1/gui/command + /v1/gui/stream (remote editing)
+│   ├── gui/               # Native GUI backend (Tauri host side)
+│   │   ├── mod.rs         # Snapshot projection + request handling
+│   │   ├── protocol.rs    # Serializable GuiCommand / GuiSnapshot
+│   │   ├── bridge.rs      # GuiBridge — the frontend's typed API
+│   │   ├── remote.rs      # RemoteTransport (HTTP + SSE)
+│   │   ├── reconnect.rs   # Connection state, backoff, reattach
+│   │   ├── ssh.rs         # `--remote` bootstrap, tunnel, version check
+│   │   └── clipboard.rs   # Clipboard bridging across the link
+│   ├── frontend/          # Frontend-agnostic runtime plumbing (TUI/headless/GUI)
+│   ├── ui/                # Terminal UI (ratatui + crossterm)
+│   ├── bin/ovim-gui/      # Standalone GUI binary
+│   ├── cli.rs             # CLI argument parsing (clap)
+│   ├── subcommands.rs     # CLI subcommand handlers
+│   ├── client.rs          # Blocking HTTP client for session-addressed commands
+│   ├── event_loop.rs      # Event loops (TUI & headless)
+│   ├── api_dispatch.rs    # handle_api_request() — API request → editor
+│   └── main.rs            # Startup, session registration, signal handling
+└── gui/                   # GUI frontend (SolidJS + Vite)
+    └── src/               # App.tsx, stateProjection.ts, predictiveEcho.ts, ...
 ```
 
 ## Gotchas
@@ -75,7 +97,7 @@ ovim/                    # Binary crate
 - **Workspace structure**: `ovim-core` contains shared logic (syntax, buffer, LSP types), `ovim` is the binary. Language/syntax code lives in ovim-core.
 - **Highlight queries**: Some grammars export `HIGHLIGHTS_QUERY`, others `HIGHLIGHT_QUERY` (singular). Some export neither and need custom `.scm` files.
 - **eprintln!()**: Breaks TUI rendering. Use only for headless debugging, then remove before committing.
-- **Large files**: `editor/mod.rs` is already ~3k lines. Refactor before adding more code there.
+- **Large files**: `ovim-core/src/editor/mod.rs` (~2.8k) and `ovim/src/gui/mod.rs` (~2.9k) are both at the refactor threshold. Split before adding more code there.
 - **Multi-agent work**: If tests fail unexpectedly, another agent may be working on the codebase. Don't `git stash` their changes.
 
 ## Common Tasks
@@ -91,7 +113,7 @@ ovim/                    # Binary crate
 2. Add variant to `ApiResponse` in `api/state.rs`
 3. Add handler in `api/handlers.rs`
 4. Add route in `api/routes.rs`
-5. Handle in `handle_api_request()` in `main.rs`
+5. Handle in `handle_api_request()` in `api_dispatch.rs`
 
 **Add new MCP tool:**
 1. Add tool definition in `api/mcp.rs::get_tools()`
@@ -99,15 +121,26 @@ ovim/                    # Binary crate
 3. Map to existing `ApiRequest` or add new one
 
 **Add new LSP feature:**
-1. Add method to `LspManager` in `lsp/mod.rs`
-2. Call from `Editor` LSP action methods
-3. Add to `pending_lsp_action` enum if async
-4. Process in `process_pending_lsp_actions()`
+1. Add method to `LspManager` in `ovim-core/src/lsp/mod.rs`
+2. Call from the `Editor` LSP action methods in `editor/lsp_integration.rs`
+3. If it must run asynchronously, add a flag to `LspIntents` (`editor/lsp_state.rs`)
+   and set it from the synchronous input path
+4. Fire it from `dispatch_pending_intents()`, which every frontend's tick calls
 
 **Add new operator:**
-1. Add function in `editor/operators.rs`
-2. Call from operator dispatch in `editor/input.rs`
-3. Add tests in `tests/`
+1. Add a variant to the `Operator` enum in `ovim-core/src/editor/operators.rs`
+2. Handle it in `ovim-core/src/editor/input/normal/operators.rs` (key dispatch
+   and motion/range application) and `input/normal/text_objects.rs`
+3. Arm it from `input/normal/pending_commands.rs` if it takes a pending key
+4. Add tests in `ovim/tests/`
+
+**Add new GUI command (Tauri ↔ editor):**
+1. Add a variant to `GuiCommand` (and a `GuiReply` shape) in `gui/protocol.rs`
+2. Map it to/from `GuiRequest` in `gui/bridge.rs`, and add the typed helper
+3. Handle it in `handle_request()` in `gui/mod.rs`
+4. Add the `#[tauri::command]` wrapper in `gui/app.rs` and register it
+5. It works remotely for free — but decide `must_keep_its_place()`: ordering is
+   the default, and only read-only queries may be overtaken
 
 **Add new language support:**
 1. Check tree-sitter grammar crate compatibility with `tree-sitter = "0.25"` on docs.rs
@@ -135,6 +168,12 @@ cargo test     # All tests
 cargo test syntax --lib              # Syntax highlighting tests
 cargo test buffer --lib              # Buffer tests
 cargo test -p ovim-core              # Core library tests only
+cargo test -p ovim gui:: --lib       # GUI bridge, projection, protocol
+
+# GUI frontend (SolidJS)
+npm test --prefix ovim/gui           # Solid DOM suite
+npm run check --prefix ovim/gui      # Type check
+npm run build --prefix ovim/gui      # Must pass before the Rust GUI build
 
 # Verify new language support
 ovim lsp check test.sql --verbose    # Check language detection
@@ -147,9 +186,11 @@ ovim lsp languages                   # List all languages
 
 Run `ovim lsp languages` to see all supported languages.
 
-**Languages with LSP**: Rust, TypeScript, JavaScript, Astro, Python, Java, Kotlin, Scala, Groovy, SQL, C#, Terraform, Go, C, C++, Ruby, Bash, JSON, YAML, HTML, CSS, TOML, Zig, Lua, Elixir
+**Languages with LSP**: Rust, TypeScript, TSX, JavaScript, Astro, Python, Java, Kotlin, Scala, Groovy, SQL, C#, Terraform, Go, C, C++, Ruby, Bash, JSON, YAML, HTML, XML, CSS, TOML, Zig, Lua, Elixir, Ghostty
 
-**Syntax highlighting only**: Markdown, HCL, Diff
+**Syntax highlighting only**: Markdown, Dockerfile, Tree-sitter Query, HCL, Diff, WGSL
+
+The list above drifts; `ovim lsp languages` is authoritative.
 
 See [user-docs/LANGUAGE_SUPPORT.md](user-docs/LANGUAGE_SUPPORT.md) for installation instructions.
 
@@ -166,6 +207,11 @@ See [user-docs/LANGUAGE_SUPPORT.md](user-docs/LANGUAGE_SUPPORT.md) for installat
 | `/v1/keys` | POST | Send keystrokes |
 | `/v1/command` | POST | Execute ex command |
 | `/v1/mcp` | POST | MCP JSON-RPC 2.0 endpoint |
+| `/v1/gui/command` | POST | One GUI command in, its reply out |
+| `/v1/gui/stream` | GET | SSE stream of projected `GuiSnapshot` frames |
+
+The same routes are also served unprefixed for backward compatibility, except
+the GUI pair, which exists only under `/v1`.
 
 For MCP protocol details, see [user-docs/MCP.md](user-docs/MCP.md).
 
@@ -181,6 +227,24 @@ For MCP protocol details, see [user-docs/MCP.md](user-docs/MCP.md).
 - `LanguageServer` handles individual server lifecycle
 - Debounced `didChange` notifications (150ms) to reduce traffic
 - Flush pending changes before hover/goto_definition to avoid stale data
+
+### Remote Editing (`ovim gui --remote user@host /path`)
+- The whole editor runs on the remote host; the local process is only the Tauri
+  shell. Remote editing is a **transport swap** under `GuiBridge`, not a second
+  editor — see `gui/remote.rs` and `gui/ssh.rs`.
+- The session is reattached, not restarted, so warm LSP, undo history and
+  in-flight AI survive a disconnect. `--fresh` is the deliberate replacement.
+- The capability arrives on the bootstrap's stdout inside the SSH channel and
+  never touches local disk.
+- **Host-header trap**: `ApiSecurity::host_is_allowed` compares against the
+  *server's own* port, which under `ssh -L` is not the port dialled. Any client
+  must pin `Host` explicitly or every request 403s.
+- State-changing commands are serialised one-per-round-trip
+  (`GuiCommand::must_keep_its_place`); only read-only queries may be overtaken.
+- Input is **dropped** while disconnected, never queued: a replayed key means
+  something different against a buffer that moved.
+- Design record: `planning/remote-editing/PLAN.md`. User docs:
+  `user-docs/remote.md`.
 
 ### API Architecture
 - Axum server on random port (port 0 → OS assigns)
@@ -217,4 +281,4 @@ curl http://127.0.0.1:PORT/v1/health | jq '.'
 
 ## User Instructions
 
-Check `PRIORITIES.md` for current priorities. Only check off tasks when done and verified.
+Check `ISSUE_TRACKER.md` for current priorities. Only check off tasks when done and verified.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ovim gives you what Neovim distros give you. LSP, tree-sitter highlighting, AI c
 - **Lua config** — `vim.opt.number = true` just works. Configure when you want to, not because you have to.
 - **Headless mode** — run without a terminal, control via REST API
 - **Native GUI** — a GPU-composited desktop shell with DOM-native editor widgets
+- **Remote editing over SSH** — `ovim gui --remote user@host /project` runs the editor on the remote host against its real toolchain; the session survives disconnects
 
 ## Install
 
@@ -83,6 +84,23 @@ the project tree. Use `j`/`k` to move, `Enter` or `l` to open, and `h` to
 collapse or move to the parent. The explorer includes safe create, rename,
 delete, copy, cut, and paste actions; live filtering; hidden and git-ignored
 file toggles; and an in-panel `?` key reference.
+
+### Remote editing
+
+Open a project on another machine and keep the window here:
+
+```bash
+ovim gui --remote user@host /srv/checkout/api
+```
+
+The editor, its language servers, its git and its test runner all run on the
+remote host, so there are no path translations and no half-working LSP. The
+session outlives the window: close the laptop, reopen, and warm language
+servers, undo history and in-flight work are still there. Predictive local echo
+keeps insert-mode typing responsive over a slow link.
+
+See [Remote Editing](user-docs/remote.md) for requirements, limits, and what
+latency does to it.
 
 ## Screenshots
 
@@ -272,6 +290,7 @@ Key modules:
 - [Configuration](user-docs/configuration.md)
 - [AI Setup](user-docs/ai.md)
 - [Headless & Automation](user-docs/headless.md)
+- [Remote Editing](user-docs/remote.md)
 - [Terminal Sessions](user-docs/terminal.md)
 - [Language Support](user-docs/LANGUAGE_SUPPORT.md)
 - [Options Reference](user-docs/options.md)

--- a/user-docs/README.md
+++ b/user-docs/README.md
@@ -15,6 +15,7 @@ ovim file.rs --headless --session dev       # Headless mode with named session
 - [Configuration](configuration.md) - `init.lua`, `languages.toml`, and common tweaks
 - [AI Setup](ai.md) - ChatGPT sign-in, Lua-first AI config, API keys, and `ai.toml` compatibility
 - [Headless & Automation](headless.md) - Sessions, REST API, subcommands
+- [Remote Editing](remote.md) - `ovim gui --remote user@host`, session persistence, latency
 - [Language Support](LANGUAGE_SUPPORT.md) - LSP + syntax support and adding languages
 - [Options](options.md) - `:set` options reference (scrolling, wrap, clipboard, etc.)
 - [Terminal Sessions](terminal.md) - `:terminal`, `:term`, `:shell`, and `:!command`

--- a/user-docs/headless.md
+++ b/user-docs/headless.md
@@ -159,16 +159,21 @@ ovim session cleanup --max-age 7
 
 When headless, ovim exposes endpoints like:
 
-- `GET /health`
-- `GET /snapshot`
-- `POST /keys`
-- `POST /paste`
-- `POST /resize`
-- `POST /command`
-- `POST /edit`
-- `POST /insert`
-- `POST /delete-lines`
-- `GET /lines`
+- `GET /v1/health`
+- `GET /v1/snapshot`
+- `POST /v1/keys`
+- `POST /v1/paste`
+- `POST /v1/resize`
+- `POST /v1/command`
+- `POST /v1/edit`
+- `POST /v1/insert`
+- `POST /v1/delete-lines`
+- `GET /v1/lines`
+- `POST /v1/mcp`
+
+The same routes are still served without the `/v1` prefix for backward
+compatibility. Those unversioned paths are deprecated; new surface is published
+only under `/v1`.
 
 Use `ovim snapshot -s <name>` instead of calling the API directly unless you need custom tooling.
 
@@ -177,3 +182,59 @@ descriptor and send `Authorization: Bearer <capability>` on every request.
 Requests with a missing/wrong capability, an unexpected Host, or any browser
 Origin are rejected. The API intentionally has no browser CORS mode or remote
 bind mode.
+
+## GUI protocol (remote editing)
+
+The same session API also carries the conversation the native GUI has with the
+editor, which is what lets a GUI on one machine drive a headless session on
+another. See [Remote editing](remote.md) for the user-facing feature; this is
+the wire surface it rides on.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/gui/command` | POST | One GUI command in, its reply out |
+| `/v1/gui/stream` | GET | Server-sent stream of projected frames |
+
+Both are published only under `/v1`, and both sit behind the same bearer
+capability and Host guard as everything else.
+
+A command is a tagged JSON object — `command` names the variant and `payload`
+carries its fields:
+
+```bash
+PORT=... CAP=...   # both from the session descriptor
+
+curl -s -X POST "http://127.0.0.1:$PORT/v1/gui/command" \
+  -H "Authorization: Bearer $CAP" -H 'Content-Type: application/json' \
+  -d '{"command":"snapshot","payload":{"columns":80,"rows":24}}'
+
+curl -s -X POST "http://127.0.0.1:$PORT/v1/gui/command" \
+  -H "Authorization: Bearer $CAP" -H 'Content-Type: application/json' \
+  -d '{"command":"key","payload":{"input":{"key":"G"}}}'
+```
+
+The reply is `{"reply":…,"result":{"Ok":…}}`. A command with no answer to give
+(`shutdown`) returns `204 No Content` instead. A command that failed *inside the
+editor* still answers `200`, with `{"Err":"…"}` in place of `Ok`, so transport
+failures and editor failures stay distinguishable.
+
+`GET /v1/gui/stream` is Server-Sent Events with `event: snapshot` and a 15 s
+keep-alive:
+
+```bash
+curl -N "http://127.0.0.1:$PORT/v1/gui/stream" -H "Authorization: Bearer $CAP"
+```
+
+A frame is a complete, viewport-sized projection of the editor — resolved
+highlight segments, layout tree, panels, theme — published on change rather
+than on a timer. Frames are only projected while somebody is subscribed, so an
+automation session that never opens the stream pays nothing for it.
+
+Two caveats for anyone writing a client:
+
+- **Set the `Host` header explicitly** when you reach the session through a
+  forwarded port. The guard compares `Host` against the *session's own* port,
+  which under `ssh -L` is not the port you dialled. An HTTP client that derives
+  `Host` from the URL will get `403` on every request.
+- **`{"command":"shutdown"}` stops the session.** Do not wire it to a window
+  closing; that is exactly what remote reattach depends on not happening.

--- a/user-docs/remote.md
+++ b/user-docs/remote.md
@@ -1,0 +1,327 @@
+# Remote editing
+
+Ovim's native GUI can drive an editor that runs on another machine over SSH:
+
+```bash
+ovim gui --remote user@host /path/to/project
+```
+
+The window is on your laptop. Everything else — the buffers, the language
+servers, git, the test runner, the AI agent, the file tree — runs on the remote
+host, against the remote toolchain and the real filesystem. Nothing is mirrored
+or synchronised, because there is only one copy.
+
+The trade is latency for fidelity: every keystroke crosses the network, and in
+return there are no path translations, no partially working language servers,
+and the session keeps running when you close the lid. Read
+[What to expect from the link](#what-to-expect-from-the-link) before deciding
+whether the trade is right for your connection.
+
+## Getting started
+
+```bash
+# Open a project directory on another host
+ovim gui --remote user@host /srv/checkout/api
+
+# Or a single file
+ovim gui --remote build-box /srv/checkout/api/src/main.rs
+
+# Replace a session that has got stuck, instead of reattaching to it
+ovim gui --remote user@host /srv/checkout/api --fresh
+```
+
+`--remote` takes `[user@]host`, or a `Host` alias from your `~/.ssh/config`. A
+non-standard port, an identity file, a jump host or a proxy command belong in
+that config file rather than on Ovim's command line — Ovim shells out to your
+`ssh`, so whatever works for `ssh user@host` works here.
+
+The path is resolved **on the remote host**, so give an absolute path, or one
+starting with `~`. Quote the tilde so your local shell does not expand it
+first:
+
+```bash
+ovim gui --remote user@host '~/projects/thing'
+```
+
+Both `ovim gui --remote …` and the standalone `ovim-gui --remote …` binary
+accept the same flags.
+
+## What runs where
+
+| On the remote host | On your machine |
+|---|---|
+| Buffers, undo history, registers | The window and the rendering |
+| Language servers, diagnostics, completion | Keyboard, mouse, IME |
+| Git, blame, diff review | The system clipboard |
+| Test runner, debugger | `strok` vector preview |
+| AI chat, its tools and its credentials | "Open externally" and window actions |
+| The file tree and every path you see | |
+
+The GUI is a projection of the editor, not a second copy of it: the frontend
+receives a viewport-sized frame of already-resolved text, highlight segments,
+panels and layout, and sends back commands. Remote editing swaps the transport
+under that conversation and changes nothing else, which is why every panel that
+works locally works remotely.
+
+That is also why the editor lives on the far side rather than the near one. A
+local buffer cannot survive a disconnect; a remote session can, and does.
+
+## Requirements on the remote host
+
+- **Ovim itself.** Ovim does not upload a copy of itself. Install it there and
+  check that a non-interactive shell can find it:
+
+  ```bash
+  ssh user@host command -v ovim
+  ```
+
+  If `ovim` is not on that `PATH`, the bootstrap also looks in
+  `~/.cargo/bin`, `~/.local/bin`, `/usr/local/bin` and `/opt/homebrew/bin`.
+
+- **A matching Ovim version.** The GUI protocol carries no version of its own,
+  so a mismatched pair fails in ways that do not name the cause. A patch
+  difference (`1.2.6` against `1.2.7`) warns and continues; a feature
+  difference (`1.2.x` against `1.3.x`) refuses. `--allow-version-mismatch`
+  overrides the refusal when you know the two builds agree.
+
+- **Its own toolchain and language servers.** rust-analyzer, pyright, gopls and
+  the rest have to be installed on the host with the code, not on the laptop.
+  Ovim's auto-install prompt runs there too, so in practice they arrive the
+  first time you open a file.
+
+- **Its own AI credentials.** The agent runs on the remote host, so it signs in
+  there. Ovim's device-code flow is designed for exactly this: press `D` in the
+  sign-in dialog and open the URL on your laptop. See
+  [Troubleshooting](troubleshooting.md#codex-sign-in-or-repeated-401-errors).
+
+- **Nothing inbound.** The session binds loopback only, and Ovim forwards that
+  port over the SSH connection it already has. No port is exposed on the remote
+  host, and no firewall rule is needed.
+
+## Sessions persist
+
+The reason for putting the editor on the far side is that it stays there.
+Closing the window leaves the session running with its warm language servers,
+its undo history, its in-flight test run and its half-finished AI conversation
+intact. Reopening reattaches to the same session:
+
+```bash
+ovim gui --remote user@host /srv/checkout/api   # starts a session
+# close the window, close the laptop, get on a train
+ovim gui --remote user@host /srv/checkout/api   # picks up where it left off
+```
+
+Reattaching is the default, and the session is found by the project path, so
+the second command has to be the same as the first. Ovim derives the session
+name from the resolved path as `gui-<basename>-<checksum>`, which is why it is
+a normal session you can inspect on the remote host:
+
+```bash
+ssh user@host
+ovim session list
+ovim session health -s gui-api-1106417393
+ovim session kill -s gui-api-1106417393
+```
+
+A session that is alive but wedged is never replaced automatically — that would
+throw away exactly the state this design exists to keep. `--fresh` is the
+deliberate way out: it stops the old session and starts a new one in its place.
+Everything the old one held is gone with it.
+
+## The connection indicator
+
+While the link is healthy there is no indicator at all. When it drops, Ovim
+reconnects on its own and says what it is doing.
+
+- **Reconnecting.** Attempts start 500 ms apart and double up to a 15 s
+  ceiling, with jitter, for up to ten minutes. The banner names the attempt,
+  the wait until the next one, and what went wrong last time. "Retry now"
+  skips the wait.
+- **The remote session has ended.** Reconnection reattaches; it never quietly
+  starts a replacement, because an empty session looks identical to a recovered
+  one. Starting a new one is offered as a separate, labelled action, and only
+  when Ovim owns the SSH link.
+- **Refused.** Authentication or host-key failures stop immediately. Repeating
+  them only repeats the refusal.
+- **Still unreachable.** The ten-minute budget ran out. The session on the far
+  side may well still be running; "Try again" is always available, because a
+  dead end you can only leave by relaunching throws away the session it was
+  protecting.
+
+**Keys typed during an outage are dropped, not queued.** This looks harsh and
+is the safe choice: in a modal editor a key means whatever the mode, pending
+operator, count and cursor make it mean *when it arrives*, and the session
+keeps being edited while your window cannot see it. A replayed `dd` would
+delete the wrong line with nothing to show that it had. Ovim reports the
+dropped input rather than storing it up.
+
+## Predictive echo
+
+Above roughly 40 ms of round-trip time, waiting for the network to draw each
+character stops being a delay and starts being the interface. Ovim borrows
+mosh's answer: over a remote link it draws the character locally and marks it
+as unconfirmed with a **dotted underline** until the editor's own frame catches
+up — usually within one round trip. If the editor disagrees, its frame wins and
+the prediction disappears.
+
+It is deliberately narrow, because showing text that is not there costs far
+more than showing text late. Predictions are only made when:
+
+- the buffer is in `INSERT` mode with no prompt, picker, completion menu or
+  overlay open, and the buffer is not read-only;
+- the key is a single Latin-range printable character with no modifier but
+  Shift (CJK, emoji and anything composed of several code points round-trip);
+- the cursor line is rendered as one unwrapped row with no horizontal scroll;
+- the editor itself certifies that the next plain character will be inserted
+  literally.
+
+**Enter, Tab and Backspace are never predicted**, nor is anything in Normal,
+Visual or Command mode, nor `}`/`)`/`]` on an otherwise blank line where
+auto-indent would reposition them. Those keys cost a full round trip, and a run
+of predicted characters pauses until the frame that accounts for them comes
+back. In practice a clean line of prose or code predicts nearly all of its
+keystrokes; a realistic edit full of `<CR>`, `<BS>` and `<Esc>` predicts
+somewhat fewer.
+
+There is nothing to configure. Predictive echo is on for remote links and off
+for local ones, where it would trade a chance of being wrong for no gain.
+
+## Clipboard
+
+Ovim bridges the two machines' clipboards in both directions, following the
+`clipboard` option rather than inventing a policy of its own (see
+[Options](options.md#clipboard)).
+
+- **Remote editor to your machine.** Whenever the remote editor writes its own
+  system clipboard — a yank or delete under the default
+  `clipboard=unnamedplus`, or an explicit `"+y` whatever the option says — the
+  text arrives on your laptop's clipboard, ready to paste into a browser. On a
+  headless remote there is usually no clipboard at all, so without the bridge
+  the yank would go nowhere.
+- **Your machine to the remote editor.** Gated on `clipboard` asking for system
+  integration. Your clipboard is handed over when the Ovim window is
+  activated — the one moment between "copied something in a browser" and
+  "pressed `p`" that Ovim can see. `set clipboard=` turns this direction off
+  entirely; the window's own paste gesture (`Cmd-V` on macOS, `Ctrl-Shift-V`
+  elsewhere) is explicit and keeps working either way.
+
+Both directions cap at 1 MiB. An oversized yank is refused loudly rather than
+spending a minute of your uplink on text nobody is going to paste; it is still
+sitting in the remote register, with `:w` and shell pipes as better ways to
+move it.
+
+Because the hand-over happens on window activation, a copy made on your laptop
+*after* the Ovim window is already focused is not seen until you focus
+something else and come back.
+
+## What to expect from the link
+
+Every keystroke round-trips. Be honest with yourself about the connection:
+
+| Link | Round trip | Feel |
+|---|---|---|
+| LAN or a local VM | 1-10 ms | Indistinguishable from local |
+| Same city, or a datacentre VPN | 10-25 ms | Fine |
+| Cross-country | 40-70 ms | Mushy; holding `j` visibly lags |
+| Transatlantic | 100-150 ms | Unpleasant |
+| Cafe wifi or tethering | 100-300 ms with jitter | Not worth it |
+
+Predictive echo makes insert-mode typing feel instant regardless, but it only
+covers the keys listed above, and there is a second, separate ceiling it cannot
+hide:
+
+**Commands that change editor state are serialised — one per round trip.** They
+have to be, because `d` arriving after its motion means something different
+from `d` arriving before it. So sustained typing faster than 1/RTT builds a
+backlog that drains in the pauses: roughly 25 keys per second at 40 ms, and
+under 7 per second at 150 ms. Predictive echo hides this while it is
+speculating, but the first unmodelled key — an Enter, a Backspace, an `Esc` —
+ends the run and the catch-up becomes visible.
+
+Bandwidth is not the constraint. Frames are viewport-sized and only sent on
+change, which is a few kilobytes gzipped; splits multiply that, since each pane
+carries its own lines.
+
+Read-only queries are exempt from the serialisation. A diff review that walks
+Git objects for several seconds does not block the keys you type while it runs.
+
+## Current limits
+
+Remote editing is complete enough for daily use, but these limits are real:
+
+- **No remote terminal.** `:terminal`, `:term`, `:shell` and `:!command` need a
+  real terminal, and the GUI has none — see
+  [Terminal sessions](terminal.md). A local GUI window says so on the status
+  line; over a remote link the request is currently dropped with no message at
+  all. Use a separate `ssh` window, or the AI chat's shell tool, which does run
+  on the remote host.
+- **`strok` vector preview runs locally.** The Vector tab shells out to `strok`
+  on the machine running the window, so it needs `strok` on your laptop rather
+  than on the remote host. See [AI setup](ai.md).
+- **Dragging an image into a remote window does not work.** The drop hands over
+  a path on your laptop, which the remote editor cannot read. Pasting an image
+  from the clipboard does work, because that carries the bytes.
+- **`:openwin` is not host-aware.** The path it produces is not tagged with
+  which machine it belongs to, so it currently does nothing over a remote link.
+  Launch the second window with its own `ovim gui --remote` instead.
+- **One host per window.** There is no mixed local/remote or multi-root
+  workspace; a window talks to exactly one editor.
+- **The GUI protocol is unversioned**, which is why the version check above
+  exists.
+
+## Driving a session behind a tunnel you already have
+
+When the tunnel is somebody else's — an existing `ssh -L`, a VPN, a container,
+or a headless session running on this machine — the low-level pair takes over
+from `--remote`:
+
+```bash
+# Copy the remote session's descriptor to this machine, then:
+ovim gui --remote-session ./api.json --remote-endpoint 127.0.0.1:8443
+```
+
+`--remote-session` takes the JSON descriptor a headless run writes on its own
+host (`<cache>/ovim/sessions/<name>.json`; see
+[Headless & Automation](headless.md#session-files)). It carries both the bearer
+capability and the port the session listens on, so neither is ever typed on a
+command line where the process table and your shell history would keep it.
+Treat that file as a credential.
+
+`--remote-endpoint` says where to dial: `HOST:PORT`, or a bare port on
+loopback. It defaults to the port in the descriptor, which is right when the
+session is on this machine. Under `ssh -L` it is the local end of the tunnel,
+while the descriptor still fixes the `Host` header the session insists on.
+
+The two forms are mutually exclusive: `--remote` conflicts with
+`--remote-session`, and `--fresh` and `--allow-version-mismatch` only mean
+something with `--remote`, since there is no bootstrap to apply them to.
+
+There is no equivalent to reattach-or-start here, and no way for Ovim to tell a
+dead tunnel from a dead session, so a client on this path keeps retrying — which
+is exactly what rides out a forward being restarted underneath it.
+
+## Under the hood
+
+`--remote` runs two SSH invocations and authenticates once. The first sends a
+small POSIX shell script on stdin, which finds `ovim` on the remote host,
+resolves the path, reattaches to or starts a headless session for it, and
+prints back the session descriptor. The second forwards that session's loopback
+port to a free port here. Both share an SSH control socket, so a host with 2FA
+does not prompt twice.
+
+The capability that authenticates the GUI to the session arrives inside the SSH
+channel and goes straight into memory. **It is never written to disk on your
+machine**, so there is no local credential file to protect or clean up.
+
+Closing the window tears down the forward and lets the control master expire.
+It does not touch the session — only an editor Ovim started in-process is
+Ovim's to stop on exit.
+
+The conversation itself runs over the session's ordinary authenticated API:
+`POST /v1/gui/command` and `GET /v1/gui/stream`. See
+[Headless & Automation](headless.md#gui-protocol-remote-editing) if you want to
+drive it yourself.
+
+## Troubleshooting
+
+See [Troubleshooting](troubleshooting.md#remote-editing).

--- a/user-docs/remote.md
+++ b/user-docs/remote.md
@@ -249,12 +249,15 @@ Git objects for several seconds does not block the keys you type while it runs.
 
 Remote editing is complete enough for daily use, but these limits are real:
 
-- **No remote terminal.** `:terminal`, `:term`, `:shell` and `:!command` need a
-  real terminal, and the GUI has none — see
-  [Terminal sessions](terminal.md). A local GUI window says so on the status
-  line; over a remote link the request is currently dropped with no message at
-  all. Use a separate `ssh` window, or the AI chat's shell tool, which does run
-  on the remote host.
+- **No interactive remote terminal.** `:terminal`, `:term` and `:shell` need a
+  real terminal to attach to, and the GUI has none — see
+  [Terminal sessions](terminal.md). Over a remote link they are refused on the
+  status line with *"Interactive terminal sessions require the TUI frontend"*.
+  Use a separate `ssh` window, or the AI chat's shell tool.
+
+  `:!command` is **not** affected: it runs on the remote host, where the code
+  is, and puts its output on the status line. `:!uname -n` reports the remote
+  machine's name, not your laptop's.
 - **`strok` vector preview runs locally.** The Vector tab shells out to `strok`
   on the machine running the window, so it needs `strok` on your laptop rather
   than on the remote host. See [AI setup](ai.md).
@@ -262,8 +265,10 @@ Remote editing is complete enough for daily use, but these limits are real:
   a path on your laptop, which the remote editor cannot read. Pasting an image
   from the clipboard does work, because that carries the bytes.
 - **`:openwin` is not host-aware.** The path it produces is not tagged with
-  which machine it belongs to, so it currently does nothing over a remote link.
-  Launch the second window with its own `ovim gui --remote` instead.
+  which machine it belongs to, so over a remote link it is refused on the
+  status line with *"Opening project windows requires the GUI frontend"* —
+  the remote editor is headless and has no window to open. Launch the second
+  window with its own `ovim gui --remote` instead.
 - **One host per window.** There is no mixed local/remote or multi-root
   workspace; a window talks to exactly one editor.
 - **The GUI protocol is unversioned**, which is why the version check above

--- a/user-docs/remote.md
+++ b/user-docs/remote.md
@@ -205,8 +205,9 @@ Ovim bridges the two machines' clipboards in both directions, following the
   entirely; the window's own paste gesture (`Cmd-V` on macOS, `Ctrl-Shift-V`
   elsewhere) is explicit and keeps working either way.
 
-Both directions cap at 1 MiB. An oversized yank is refused loudly rather than
-spending a minute of your uplink on text nobody is going to paste; it is still
+Both directions cap at 1 MiB. An oversized yank is not bridged — the alternative
+is spending a minute of your uplink on text nobody is going to paste — and the
+refusal goes to the log rather than to the status line. The text is still
 sitting in the remote register, with `:w` and shell pipes as better ways to
 move it.
 
@@ -238,9 +239,12 @@ under 7 per second at 150 ms. Predictive echo hides this while it is
 speculating, but the first unmodelled key — an Enter, a Backspace, an `Esc` —
 ends the run and the catch-up becomes visible.
 
-Bandwidth is not the constraint. Frames are viewport-sized and only sent on
-change, which is a few kilobytes gzipped; splits multiply that, since each pane
-carries its own lines.
+Latency is what you feel, but bandwidth is not free either. Frames are
+viewport-sized and only sent on change — and each change sends a whole frame,
+uncompressed: roughly 20 KB for an 80×24 view of highlighted code and 45 KB for
+120×35. Splits multiply that, since each pane carries its own lines. Nothing on
+the path compresses it, so on a link under a couple of Mbit/s the frames matter
+as much as the round trips do.
 
 Read-only queries are exempt from the serialisation. A diff review that walks
 Git objects for several seconds does not block the keys you type while it runs.
@@ -251,13 +255,19 @@ Remote editing is complete enough for daily use, but these limits are real:
 
 - **No interactive remote terminal.** `:terminal`, `:term` and `:shell` need a
   real terminal to attach to, and the GUI has none — see
-  [Terminal sessions](terminal.md). Over a remote link they are refused on the
-  status line with *"Interactive terminal sessions require the TUI frontend"*.
-  Use a separate `ssh` window, or the AI chat's shell tool.
+  [Terminal sessions](terminal.md). Typed over a remote link they do nothing
+  at all: the request is queued for a frontend that can host a terminal, the
+  remote session is headless, and no message is shown. Use a separate `ssh`
+  window, or the AI chat's shell tool.
 
-  `:!command` is **not** affected: it runs on the remote host, where the code
-  is, and puts its output on the status line. `:!uname -n` reports the remote
-  machine's name, not your laptop's.
+  `:!command` typed at the command line goes the same way, for the same
+  reason — the interactive path queues it for a terminal-owning frontend. It
+  does work through the session's API, where it runs on the remote host, where
+  the code is, and reports its output. From that host:
+
+  ```bash
+  ovim exec '!uname -n' -s gui-api-1106417393   # the remote machine's name
+  ```
 - **`strok` vector preview runs locally.** The Vector tab shells out to `strok`
   on the machine running the window, so it needs `strok` on your laptop rather
   than on the remote host. See [AI setup](ai.md).
@@ -265,10 +275,10 @@ Remote editing is complete enough for daily use, but these limits are real:
   a path on your laptop, which the remote editor cannot read. Pasting an image
   from the clipboard does work, because that carries the bytes.
 - **`:openwin` is not host-aware.** The path it produces is not tagged with
-  which machine it belongs to, so over a remote link it is refused on the
-  status line with *"Opening project windows requires the GUI frontend"* —
-  the remote editor is headless and has no window to open. Launch the second
-  window with its own `ovim gui --remote` instead.
+  which machine it belongs to, and the remote editor is headless and has no
+  window to open, so over a remote link it is queued and dropped in the same
+  silence as `:terminal`. Launch the second window with its own
+  `ovim gui --remote` instead.
 - **One host per window.** There is no mixed local/remote or multi-root
   workspace; a window talks to exactly one editor.
 - **The GUI protocol is unversioned**, which is why the version check above

--- a/user-docs/troubleshooting.md
+++ b/user-docs/troubleshooting.md
@@ -66,6 +66,105 @@ To force an account change or replace damaged credentials, close Ovim, remove
 Do not copy `~/.codex/auth.json` into Ovim. Sharing rotating refresh tokens with
 Codex CLI can make either application lose authentication periodically.
 
+## Remote editing
+
+For what remote editing does and what it cannot do, see
+[Remote editing](remote.md). Ovim's own error messages name the next step; this
+is the same list with a little more room.
+
+### `No 'ovim' was found on <host>`
+
+Ovim does not upload itself. Install it on the remote host, then check that a
+*non-interactive* SSH shell can see it — this is a different `PATH` from the one
+your login shell uses:
+
+```bash
+ssh user@host command -v ovim
+```
+
+That must print a path. If it does not, put `ovim` in `~/.cargo/bin`,
+`~/.local/bin`, `/usr/local/bin` or `/opt/homebrew/bin`, which the bootstrap
+also searches, or export a `PATH` from `~/.ssh/environment` or your shell's
+non-interactive rc file.
+
+### `'<path>' does not exist on <host>`
+
+The path after `--remote user@host` is resolved on the remote host, never on
+yours. Give an absolute remote path; a leading `~` is expanded there, so quote
+it (`'~/projects/thing'`) to stop your local shell expanding it first.
+
+### `Ovim on <host> did not finish starting a session … in time`
+
+The session did not write its descriptor within 30 seconds. Run the same thing
+by hand to see what it is stuck on:
+
+```bash
+ssh user@host
+ovim /path/to/project --headless --session probe
+```
+
+### SSH refuses the connection
+
+Ovim shells out to your `ssh`, so anything that stops `ssh user@host` stops
+Ovim too. Run it by hand first.
+
+| Message | Remedy |
+|---|---|
+| `could not be resolved` | Check the spelling, or give the alias a `Host` entry in `~/.ssh/config`. |
+| `did not pass host key verification` | Run `ssh user@host` once by hand, see the key, and decide. Ovim will not answer that for you. |
+| `refused the SSH authentication` | `ssh-add` your key, or `ssh-copy-id user@host`. |
+| `could not be reached over SSH` | Check the host is up. A non-standard port belongs in `~/.ssh/config`, not in `--remote`. |
+
+### Version mismatch
+
+The GUI protocol is not versioned, so a mismatched pair fails as a missing
+field rather than as anything that names the cause. A patch difference warns and
+continues; a feature difference refuses. Upgrade whichever side is older, or
+pass `--allow-version-mismatch` when you know the two builds agree.
+
+The same refusal appears as "did not report a version this Ovim could read"
+when the binary found on the remote host is not Ovim at all.
+
+### The session is wedged
+
+Ovim never replaces a live session on its own — that would silently discard the
+undo history and warm language servers the session exists to keep. Relaunch with
+`--fresh` to stop it and start a replacement, accepting that loss:
+
+```bash
+ovim gui --remote user@host /path/to/project --fresh
+```
+
+To look before you leap, the session is an ordinary Ovim session on the remote
+host, named `gui-<basename>-<checksum>`:
+
+```bash
+ssh user@host
+ovim session list
+ovim session health -s gui-project-1106417393
+```
+
+### "The remote session has ended"
+
+Reconnecting reattaches; it never quietly starts a replacement, because an empty
+session and a recovered one look identical. Whatever the old session held is
+gone. The banner offers "Start a new session" as a separate, labelled action.
+
+### Keystrokes go missing while the indicator is showing
+
+Input during an outage is dropped rather than queued, on purpose: a replayed key
+means whatever the mode and cursor make it mean when it *arrives*, against a
+buffer that may have moved. Wait for the indicator to clear.
+
+### Typing lags behind in bursts
+
+Commands that change editor state are serialised, one per round trip, so
+sustained typing faster than 1/RTT builds a backlog — about 25 keys per second
+at 40 ms, under 7 at 150 ms. Predictive echo hides it while it can, but Enter,
+Tab and Backspace end a predicted run and the catch-up becomes visible. Nothing
+is lost; it drains in the pauses. See
+[What to expect from the link](remote.md#what-to-expect-from-the-link).
+
 ## Logs & debug mode
 
 If something “mysteriously” fails (or the UI gets corrupted), the first thing to grab is the log files.


### PR DESCRIPTION
Final chunk of the remote-editing work. Docs only — no code changed.

Stacked on #18.

## New

**`user-docs/remote.md`** — getting started, what runs where, requirements on the remote host, session persistence and `--fresh`, the connection indicator, predictive echo, clipboard, and troubleshooting. Written to the depth and tone of `headless.md` and `terminal.md`.

The limits are stated plainly rather than buried, because a doc that oversells this will burn people: the RTT table, the one-command-per-round-trip ceiling (~25 keys/s at 40ms, under 7 at 150ms), what predictive echo does *not* cover, the remote host needing its own toolchain/language servers/AI credentials, `strok` running locally, image drag-drop, `:openwin`, and no interactive remote terminal.

**`user-docs/troubleshooting.md`** — a remote section built from the actual error strings in `ovim/src/gui/ssh.rs`, so the remedy a user reads matches what the program tells them.

**`user-docs/headless.md`** — the two GUI protocol routes, the tagged-JSON command shape, and the two client traps (`Host` header, `shutdown`). Endpoint list moved to `/v1`, with the unprefixed paths marked deprecated.

`README.md` and `user-docs/README.md` updated.

## `CLAUDE.md` had drifted badly

The contributor map described a codebase that no longer exists. Corrected:

- The architecture tree showed `ovim/src/editor/` with `input.rs`/`motions.rs`/`operators.rs` as *files*. The editor is in `ovim-core/src/editor/`, and `input/`/`motions/` are directories. `ovim/src/gui/` and the frontend in `ovim/gui/` were absent entirely.
- `handle_api_request()` is in `api_dispatch.rs`, not `main.rs`.
- The LSP recipe named `pending_lsp_action` and `process_pending_lsp_actions()`. Neither exists; it is `LspIntents` fired by `dispatch_pending_intents()`.
- The operator recipe was wrong twice over — `editor/operators.rs` is a 19-line enum and dispatch lives in `input/normal/operators.rs`.
- `:session start NAME` was documented as the TUI opt-in; it is now deliberately a migration error.
- Language lists were five entries short.
- **`PRIORITIES.md` no longer exists** (deleted in the open-source-release commit) but the "User Instructions" section still pointed at it. Repointed at `ISSUE_TRACKER.md` — worth confirming that's the intent.

Added a `### Remote Editing` block, an "Add new GUI command" recipe, and the frontend test commands.

## Corrections I made to the docs before merging

The chunk originally documented three ex commands as failing *silently* over a remote link. I tested all of them against a live session and that was wrong on every count:

| Command | Actual behaviour over remote |
|---|---|
| `:terminal` / `:term` / `:shell` | Refused on the status line: *"Interactive terminal sessions require the TUI frontend"* |
| `:openwin` | Refused: *"Opening project windows requires the GUI frontend"* |
| `:!command` | **Works.** Runs on the remote host and reports output |

`:!command` working is the notable one — it's correct and desirable behaviour that the draft described as broken. `!pwd` returns the session's working directory and `!uname -n` the remote hostname, which is exactly right for remote editing: shell commands run where the code is. The limits section now says so.

## Verification

Flags checked against `--help` and by running every combination (`--fresh`/`--allow-version-mismatch` requiring `--remote`, `--remote` conflicting with `--remote-session`, and so on). Two real bootstrap failures driven end to end (DNS, SSH auth refusal). The routes exercised with `curl` against a live session covering SSE, both reply shapes, `204`, `401` and `403`. The ignored end-to-end suite run one test per fresh session. Link/anchor checker clean across README, CLAUDE.md and all of `user-docs/`.

## Noted, not fixed

- `README.md`'s syntax-only language list omits Dockerfile and Tree-sitter Query; its "23 languages with LSP" count would need auditing alongside.
- `ovim/src/api/routes.rs` says the unversioned routes "will be removed in ovim v1.0"; the crate is at 1.2.7.

## Not verified by running

Anything needing a second host — reattach across launches, `--fresh` killing a live remote session, the control-socket "authenticate once", and the version-mismatch refusal. All are covered by `gui::ssh` unit tests against a real `/bin/sh`; the same environment limitation applies as in #15 and #16. The predictive-echo underline and the clipboard hand-over on window activation were also not observed in a real window.